### PR TITLE
Detailed SSL warnings for tls_connect and tls_accept

### DIFF
--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -10,3 +10,5 @@ struct tls {
 	X509 *cert;
 	char *pass;  /* password for private key */
 };
+
+void tls_flush_error(void);

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -242,29 +242,29 @@ static int tls_connect(struct tls_conn *tc)
 	r = SSL_connect(tc->ssl);
 	if (r <= 0) {
 		const int ssl_err = SSL_get_error(tc->ssl, r);
-        int err = 0;
+		int err = 0;
 
 		switch (ssl_err) {
 
 		case SSL_ERROR_WANT_READ:
 			break;
-        
-        case SSL_ERROR_SYSCALL:
-        case SSL_ERROR_SSL:
-            DEBUG_WARNING("connect error: ");
-            ERR_print_errors_fp(stderr);
-            err = EPROTO;
-            break;
+		
+		case SSL_ERROR_SYSCALL:
+		case SSL_ERROR_SSL:
+			DEBUG_WARNING("connect error: ");
+			ERR_print_errors_fp(stderr);
+			err = EPROTO;
+			break;
 
 		default:
 			DEBUG_WARNING("connect error: %i\n", ssl_err);
 			err = EPROTO;
 		}
-        
-        ERR_clear_error();
-        
-        if (err)
-            return err;
+		
+		ERR_clear_error();
+		
+		if (err)
+			return err;
 	}
 
 	check_timer(tc);
@@ -282,19 +282,19 @@ static int tls_accept(struct tls_conn *tc)
 	r = SSL_accept(tc->ssl);
 	if (r <= 0) {
 		const int ssl_err = SSL_get_error(tc->ssl, r);
-        int err = 0;
+		int err = 0;
 
 		switch (ssl_err) {
 
 		case SSL_ERROR_WANT_READ:
 			break;
-        
-        case SSL_ERROR_SYSCALL:
-        case SSL_ERROR_SSL:
-            DEBUG_WARNING("accept error: ");
-            ERR_print_errors_fp(stderr);
-            err = EPROTO;
-            break;
+		
+		case SSL_ERROR_SYSCALL:
+		case SSL_ERROR_SSL:
+			DEBUG_WARNING("accept error: ");
+			ERR_print_errors_fp(stderr);
+			err = EPROTO;
+			break;
 
 		default:
 			DEBUG_WARNING("accept error: %i\n", ssl_err);
@@ -302,9 +302,9 @@ static int tls_accept(struct tls_conn *tc)
 		}
 
 		ERR_clear_error();
-        
-        if (err)
-            return err;
+		
+		if (err)
+			return err;
 	}
 
 	check_timer(tc);
@@ -365,12 +365,12 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 
 			tc->estabh(tc->arg);
 
-                        nrefs = mem_nrefs(tc);
-                        mem_deref(tc);
+						nrefs = mem_nrefs(tc);
+						mem_deref(tc);
 
-                        /* check if connection was deref'd from handler */
-                        if (nrefs == 1)
-                                return;
+						/* check if connection was deref'd from handler */
+						if (nrefs == 1)
+								return;
 		}
 	}
 

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -258,15 +258,9 @@ static int tls_connect(struct tls_conn *tc)
 		case SSL_ERROR_WANT_READ:
 			break;
 
-		case SSL_ERROR_SYSCALL:
-		case SSL_ERROR_SSL:
-			DEBUG_WARNING("connect error: %i\n", ssl_err);
-			ERR_print_errors_cb(print_error, NULL);
-			err = EPROTO;
-			break;
-
 		default:
 			DEBUG_WARNING("connect error: %i\n", ssl_err);
+			ERR_print_errors_cb(print_error, NULL);
 			err = EPROTO;
 			break;
 		}
@@ -299,15 +293,9 @@ static int tls_accept(struct tls_conn *tc)
 		case SSL_ERROR_WANT_READ:
 			break;
 
-		case SSL_ERROR_SYSCALL:
-		case SSL_ERROR_SSL:
-			DEBUG_WARNING("accept error: %i\n", ssl_err);
-			ERR_print_errors_cb(print_error, NULL);
-			err = EPROTO;
-			break;
-
 		default:
 			DEBUG_WARNING("accept error: %i\n", ssl_err);
+			ERR_print_errors_cb(print_error, NULL);
 			err = EPROTO;
 			break;
 		}

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -248,7 +248,7 @@ static int tls_connect(struct tls_conn *tc)
 
 		case SSL_ERROR_WANT_READ:
 			break;
-		
+
 		case SSL_ERROR_SYSCALL:
 		case SSL_ERROR_SSL:
 			DEBUG_WARNING("connect error: ");
@@ -259,10 +259,11 @@ static int tls_connect(struct tls_conn *tc)
 		default:
 			DEBUG_WARNING("connect error: %i\n", ssl_err);
 			err = EPROTO;
+			break;
 		}
-		
+
 		ERR_clear_error();
-		
+
 		if (err)
 			return err;
 	}
@@ -288,7 +289,7 @@ static int tls_accept(struct tls_conn *tc)
 
 		case SSL_ERROR_WANT_READ:
 			break;
-		
+
 		case SSL_ERROR_SYSCALL:
 		case SSL_ERROR_SSL:
 			DEBUG_WARNING("accept error: ");
@@ -299,10 +300,11 @@ static int tls_accept(struct tls_conn *tc)
 		default:
 			DEBUG_WARNING("accept error: %i\n", ssl_err);
 			err = EPROTO;
+			break;
 		}
 
 		ERR_clear_error();
-		
+
 		if (err)
 			return err;
 	}
@@ -365,12 +367,12 @@ static void conn_recv(struct tls_conn *tc, struct mbuf *mb)
 
 			tc->estabh(tc->arg);
 
-						nrefs = mem_nrefs(tc);
-						mem_deref(tc);
+			nrefs = mem_nrefs(tc);
+			mem_deref(tc);
 
-						/* check if connection was deref'd from handler */
-						if (nrefs == 1)
-								return;
+			/* check if connection was deref'd from handler */
+			if (nrefs == 1)
+					return;
 		}
 	}
 

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -233,6 +233,14 @@ static void check_timer(struct tls_conn *tc)
 #endif
 
 
+static int print_error(const char *str, size_t len, void *u)
+{
+	DEBUG_WARNING("%b", str, len);
+	/* return code > 0: Continue outputting the error report */
+	return 1;
+}
+
+
 static int tls_connect(struct tls_conn *tc)
 {
 	int r;
@@ -251,8 +259,8 @@ static int tls_connect(struct tls_conn *tc)
 
 		case SSL_ERROR_SYSCALL:
 		case SSL_ERROR_SSL:
-			DEBUG_WARNING("connect error: ");
-			ERR_print_errors_fp(stderr);
+			DEBUG_WARNING("connect error: %i\n", ssl_err);
+			ERR_print_errors_cb(print_error, NULL);
 			err = EPROTO;
 			break;
 
@@ -292,8 +300,8 @@ static int tls_accept(struct tls_conn *tc)
 
 		case SSL_ERROR_SYSCALL:
 		case SSL_ERROR_SSL:
-			DEBUG_WARNING("accept error: ");
-			ERR_print_errors_fp(stderr);
+			DEBUG_WARNING("accept error: %i\n", ssl_err);
+			ERR_print_errors_cb(print_error, NULL);
 			err = EPROTO;
 			break;
 

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -233,8 +233,9 @@ static void check_timer(struct tls_conn *tc)
 #endif
 
 
-static int print_error(const char *str, size_t len, void *u)
+static int print_error(const char *str, size_t len, void *unused)
 {
+	(void)unused;
 	DEBUG_WARNING("%b", str, len);
 	/* return code > 0: Continue outputting the error report */
 	return 1;


### PR DESCRIPTION
It took me a lot of time to find out why my calls to `tls_connect` and `tls_accept` failed. Eventually I found out that my peers have used incompatible TLS versions and at some point could not negotiate a cipher suite. These changes print out the additional information OpenSSL provides when such events occur which makes it easier to detect the cause of the problem.