### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -273,6 +273,16 @@ ifeq ($(OS),netbsd)
 	AFLAGS		:= cru
 	HAVE_KQUEUE	:= 1
 endif
+ifeq ($(OS),dragonfly)
+	CFLAGS		+= -fPIC -DDRAGONFLY
+	LFLAGS		+= -fPIC
+	SH_LFLAGS	+= -shared
+	MOD_LFLAGS	+=
+	APP_LFLAGS	+= -rdynamic
+	AR		:= ar
+	AFLAGS		:= cru
+	HAVE_KQUEUE	:= 1
+endif
 ifeq ($(OS),freebsd)
 	CFLAGS		+= -fPIC -DFREEBSD
 	LFLAGS		+= -fPIC

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -221,7 +221,7 @@ BIN_SUFFIX	:=
 
 ifeq ($(OS),solaris)
 	CFLAGS		+= -fPIC -DSOLARIS
-	LIBS		+= -ldl -lsocket -lnsl
+	LIBS		+= -ldl -lsocket -lnsl -lresolv
 	LFLAGS		+= -fPIC
 	SH_LFLAGS	+= -G
 	MOD_LFLAGS	+=
@@ -231,7 +231,7 @@ ifeq ($(OS),solaris)
 endif
 ifeq ($(OS),linux)
 	CFLAGS		+= -fPIC -DLINUX
-	LIBS		+= -ldl
+	LIBS		+= -ldl -lresolv
 	LFLAGS		+= -fPIC
 	SH_LFLAGS	+= -shared
 	MOD_LFLAGS	+=
@@ -241,6 +241,7 @@ ifeq ($(OS),linux)
 endif
 ifeq ($(OS),darwin)
 	CFLAGS		+= -fPIC -dynamic -DDARWIN
+	LIBS		+= -lresolv
 ifneq (,$(findstring Apple, $(CC_LONGVER)))
 	CFLAGS		+= -Wshorten-64-to-32
 endif
@@ -263,6 +264,7 @@ endif
 endif
 ifeq ($(OS),netbsd)
 	CFLAGS		+= -fPIC -DNETBSD
+	LIBS		+= -lresolv
 	LFLAGS		+= -fPIC
 	SH_LFLAGS	+= -shared
 	MOD_LFLAGS	+=
@@ -535,15 +537,10 @@ HAVE_EPOLL   := $(shell [ -f $(SYSROOT)/include/sys/epoll.h ] || \
 			[ -f $(SYSROOT)/include/$(MACHINE)/sys/epoll.h ] \
 			&& echo "1")
 endif
-ifneq ($(OS),openbsd)
-HAVE_LIBRESOLV := $(shell [ -f $(SYSROOT)/include/resolv.h ] && echo "1")
-endif
 
+HAVE_LIBRESOLV := $(shell [ -f $(SYSROOT)/include/resolv.h ] && echo "1")
 ifneq ($(HAVE_LIBRESOLV),)
 CFLAGS  += -DHAVE_LIBRESOLV
-ifneq ($(OS),freebsd)
-LIBS    += -lresolv
-endif
 endif
 ifneq ($(HAVE_SYSLOG),)
 CFLAGS  += -DHAVE_SYSLOG

--- a/src/dns/mod.mk
+++ b/src/dns/mod.mk
@@ -13,7 +13,7 @@ SRCS	+= dns/rr.c
 SRCS	+= dns/rrlist.c
 
 ifneq ($(HAVE_LIBRESOLV),)
-ifeq ($(filter-out netbsd openbsd,$(OS)),)
+ifeq ($(filter-out netbsd,$(OS)),)
 SRCS	+= dns/bsd/srv.c
 else
 SRCS	+= dns/res.c

--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -61,7 +61,9 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	*n = i;
 
  out:
+#ifndef OPENBSD
 	res_close();
+#endif
 
 	return err;
 }

--- a/src/main/openssl.c
+++ b/src/main/openssl.c
@@ -26,7 +26,7 @@ static pthread_mutex_t *lockv;
 static inline unsigned long threadid(void)
 {
 #if defined (DARWIN) || defined (FREEBSD) || defined (OPENBSD) || \
-	defined (NETBSD)
+	defined (NETBSD) || defined (DRAGONFLY)
 	return (unsigned long)(void *)pthread_self();
 #else
 	return (unsigned long)pthread_self();


### PR DESCRIPTION
This was discussed on mailing list.  I've tested it on dfly back then, and it worked.  I had a report from someone who was successfully using baresip on dfly with these changes.