### PR TITLE
tls: add tls_flush_error to dump openssl errors

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -730,3 +730,18 @@ int tls_set_servername(struct tls_conn *tc, const char *servername)
 
 	return 0;
 }
+
+
+static int print_error(const char *str, size_t len, void *unused)
+{
+	(void)unused;
+	DEBUG_WARNING("%b", str, len);
+
+	return 1;
+}
+
+
+void tls_flush_error(void)
+{
+	ERR_print_errors_cb(print_error, NULL);
+}

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -10,3 +10,6 @@ struct tls {
 	X509 *cert;
 	char *pass;  /* password for private key */
 };
+
+
+void tls_flush_error(void);

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -243,7 +243,7 @@ static int tls_connect(struct tls_conn *tc)
 	if (r <= 0) {
 		const int ssl_err = SSL_get_error(tc->ssl, r);
 
-		ERR_clear_error();
+		tls_flush_error();
 
 		switch (ssl_err) {
 
@@ -272,7 +272,7 @@ static int tls_accept(struct tls_conn *tc)
 	if (r <= 0) {
 		const int ssl_err = SSL_get_error(tc->ssl, r);
 
-		ERR_clear_error();
+		tls_flush_error();
 
 		switch (ssl_err) {
 


### PR DESCRIPTION
original patch by Lennart Grahl and Richard Aas

this patch is a continuation of https://github.com/creytiv/re/pull/1

as a first step I suggest we do only the necessary changes for dtls.c
then later it it works well, we can call tls_flush_error from more places.

@richaas please review and merge to master
