### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -282,6 +282,16 @@ ifeq ($(OS),freebsd)
 	AFLAGS		:= cru
 	HAVE_KQUEUE	:= 1
 endif
+ifeq ($(OS),dragonfly)
+	CFLAGS		+= -fPIC -DDRAGONFLY
+	LFLAGS		+= -fPIC
+	SH_LFLAGS	+= -shared
+	MOD_LFLAGS	+=
+	APP_LFLAGS	+= -rdynamic
+	AR		:= ar
+	AFLAGS		:= cru
+	HAVE_KQUEUE	:= 1
+endif
 ifeq ($(OS),openbsd)
 	CFLAGS		+= -fPIC -DOPENBSD
 	LFLAGS		+= -fPIC

--- a/src/main/openssl.c
+++ b/src/main/openssl.c
@@ -26,7 +26,7 @@ static pthread_mutex_t *lockv;
 static inline unsigned long threadid(void)
 {
 #if defined (DARWIN) || defined (FREEBSD) || defined (OPENBSD) || \
-	defined (NETBSD)
+	defined (NETBSD) || defined (DRAGONFLY)
 	return (unsigned long)(void *)pthread_self();
 #else
 	return (unsigned long)pthread_self();


### PR DESCRIPTION
Minimal changes required to build and use `libre` on DragonFly BSD.  It is a followup to PR #6.