### PR TITLE
Use _BSD_SOURCE to unhide BSD networking facilities

### DIFF
--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <string.h>
 #include <unistd.h>
 #include <sys/ioctl.h>

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
Required on Linux with musl.

(Sorry for PR #17, something wrong happened to my tree.)