### PR TITLE
When checking for LibreSSL, use LIBRESSL_VERSION_NUMBER

### DIFF
--- a/src/hmac/openssl/hmac.c
+++ b/src/hmac/openssl/hmac.c
@@ -21,7 +21,7 @@ static void destructor(void *arg)
 	struct hmac *hmac = arg;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	if (hmac->ctx)
 		HMAC_CTX_free(hmac->ctx);
 #else
@@ -61,7 +61,7 @@ int hmac_create(struct hmac **hmacp, enum hmac_hash hash,
 		return ENOMEM;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	hmac->ctx = HMAC_CTX_new();
 	if (!hmac->ctx) {
 		ERR_clear_error();

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -46,7 +46,7 @@ static void destructor(void *data)
 	mem_deref(tls->pass);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	if (tls->method_tcp)
 		BIO_meth_free(tls->method_tcp);
@@ -106,7 +106,7 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 #ifdef USE_OPENSSL_DTLS
 	case TLS_METHOD_DTLSV1:
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 		tls->ctx = SSL_CTX_new(DTLS_method());
 #else
@@ -123,7 +123,7 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 
 	case TLS_METHOD_DTLSV1_2:
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 		tls->ctx = SSL_CTX_new(DTLS_method());
 #else
@@ -182,7 +182,7 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	tls->method_tcp = tls_method_tcp();
 	tls->method_udp = tls_method_udp();

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -6,7 +6,7 @@
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 #define SSL_state SSL_get_state
 #define SSL_ST_OK TLS_ST_OK
 #endif
@@ -17,7 +17,7 @@ struct tls {
 	X509 *cert;
 	char *pass;  /* password for private key */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	BIO_METHOD *method_tcp;
 	BIO_METHOD *method_udp;
 #endif
@@ -25,7 +25,7 @@ struct tls {
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 BIO_METHOD *tls_method_tcp(void);
 BIO_METHOD *tls_method_udp(void);
 #endif

--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -55,7 +55,7 @@ static void destructor(void *arg)
 static int bio_create(BIO *b)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	BIO_set_init(b, 1);
 	BIO_set_data(b, NULL);
@@ -77,7 +77,7 @@ static int bio_destroy(BIO *b)
 		return 0;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	BIO_set_init(b, 0);
 	BIO_set_data(b, NULL);
@@ -95,7 +95,7 @@ static int bio_destroy(BIO *b)
 static int bio_write(BIO *b, const char *buf, int len)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	struct tls_conn *tc = BIO_get_data(b);
 #else
@@ -373,7 +373,7 @@ int tls_start_tcp(struct tls_conn **ptc, struct tls *tls, struct tcp_conn *tcp,
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	tc->sbio_out = BIO_new(tls->method_tcp);
 #else
@@ -387,7 +387,7 @@ int tls_start_tcp(struct tls_conn **ptc, struct tls *tls, struct tcp_conn *tcp,
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	BIO_set_data(tc->sbio_out, tc);
 #else
@@ -409,7 +409,7 @@ int tls_start_tcp(struct tls_conn **ptc, struct tls *tls, struct tcp_conn *tcp,
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 BIO_METHOD *tls_method_tcp(void)
 {

--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -132,7 +132,7 @@ static long bio_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || \
-	OPENSSL_VERSION_NUMBER >= 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 static struct bio_method_st bio_tcp_send = {
 	BIO_TYPE_SOURCE_SINK,
 	"tcp_send",

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -163,7 +163,7 @@ static long bio_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || \
-	OPENSSL_VERSION_NUMBER >= 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 static struct bio_method_st bio_udp_send = {
 	BIO_TYPE_SOURCE_SINK,
 	"udp_send",

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -65,7 +65,7 @@ struct tls_conn {
 static int bio_create(BIO *b)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	BIO_set_init(b, 1);
 	BIO_set_data(b, NULL);
@@ -87,7 +87,7 @@ static int bio_destroy(BIO *b)
 		return 0;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 
 	BIO_set_init(b, 0);
 	BIO_set_data(b, NULL);
@@ -105,7 +105,7 @@ static int bio_destroy(BIO *b)
 static int bio_write(BIO *b, const char *buf, int len)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	struct tls_conn *tc = BIO_get_data(b);
 #else
 	struct tls_conn *tc = b->ptr;
@@ -133,7 +133,7 @@ static int bio_write(BIO *b, const char *buf, int len)
 static long bio_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	struct tls_conn *tc = BIO_get_data(b);
 #else
 	struct tls_conn *tc = b->ptr;
@@ -473,7 +473,7 @@ static int conn_alloc(struct tls_conn **ptc, struct tls *tls,
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	tc->sbio_out = BIO_new(tls->method_udp);
 #else
 	tc->sbio_out = BIO_new(&bio_udp_send);
@@ -486,7 +486,7 @@ static int conn_alloc(struct tls_conn **ptc, struct tls *tls,
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 	BIO_set_data(tc->sbio_out, tc);
 #else
 	tc->sbio_out->ptr = tc;
@@ -808,7 +808,7 @@ void dtls_set_mtu(struct dtls_sock *sock, size_t mtu)
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-	OPENSSL_VERSION_NUMBER < 0x20000000L
+	!defined(LIBRESSL_VERSION_NUMBER)
 BIO_METHOD *tls_method_udp(void)
 {
 	BIO_METHOD *method;


### PR DESCRIPTION
To avoid collision with potential future release of OpenSSL 2.0.0.

(For context see PR #9.)