### PR TITLE
Detect resolver API based on __RES version

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -221,7 +221,7 @@ BIN_SUFFIX	:=
 
 ifeq ($(OS),solaris)
 	CFLAGS		+= -fPIC -DSOLARIS
-	LIBS		+= -ldl -lsocket -lnsl
+	LIBS		+= -ldl -lresolv -lsocket -lnsl
 	LFLAGS		+= -fPIC
 	SH_LFLAGS	+= -G
 	MOD_LFLAGS	+=

--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -25,7 +25,7 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	uint32_t i;
 	int ret, err;
 
-#ifdef OPENBSD
+#if defined (__RES) && __RES <= 19991006
 	ret = res_init();
 	state = _res;
 #else
@@ -56,8 +56,7 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	*n = i;
 
  out:
-#ifdef OPENBSD
-#else
+#if !defined (__RES) || __RES > 19991006
 	res_nclose(&state);
 #endif
 


### PR DESCRIPTION
`__RES` is resolver version expressed as date.  It allows rather reliably determine whether implementation supports reentrant API or not.  If implementation does not define `__RES`, assume reentrant API.