### PR TITLE
Fixes for Solaris 11 and Illumos (Solaris 10)

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -182,10 +182,12 @@ endif
 endif
 
 # Compiler dependency flags
+ifeq ($(CC_NAME),$(filter $(CC_NAME),gcc clang))
 ifeq ($(CC_SHORTVER), 2.9x)
 	DFLAGS		= -MD
 else
 	DFLAGS		= -MD -MF $(@:.o=.d) -MT $@
+endif
 endif
 
 
@@ -344,6 +346,9 @@ endif
 ifeq ($(ARCH),)
 ifeq ($(CC_NAME),$(filter $(CC_NAME),gcc clang))
 PREDEF	:= $(shell $(CC) -dM -E -x c $(EXTRA_CFLAGS) $(CFLAGS) /dev/null)
+else ifeq ($(CCNAME),suncc)
+PREFEF	:= $(shell $(CC) -xdumpmacros -E /dev/null 2>&1)
+endif
 
 ifneq ($(strip $(filter i386 __i386__ __i386 _M_IX86 __X86__ _X86_, \
 	$(PREDEF))),)
@@ -404,7 +409,6 @@ endif
 
 endif
 
-endif
 endif
 
 

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -75,9 +75,6 @@ endif
 ifeq ($(CC),)
 	CC := gcc
 endif
-ifeq ($(CC),cc)
-	CC := gcc
-endif
 LD := $(CC)
 CC_LONGVER := $(shell if $(CC) -v 2>/dev/null; then \
 						$(CC) -v 2>&1 ;\

--- a/src/fmt/pl.c
+++ b/src/fmt/pl.c
@@ -6,7 +6,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #ifdef HAVE_STRINGS_H
-#define __EXTENSIONS__ 1
+#define _XPG4_2
 #include <strings.h>
 #endif
 #include <string.h>

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -155,11 +155,7 @@ static struct re global_re = {
 
 static void poll_close(struct re *re);
 
-#ifdef SOLARIS
-static pthread_once_t pt_once = {PTHREAD_ONCE_INIT};
-#else
 static pthread_once_t pt_once = PTHREAD_ONCE_INIT;
-#endif
 static pthread_key_t  pt_key;
 
 


### PR DESCRIPTION
These commits clean up some warnings when compiling libre on Illumos distributions and on Oracle Solaris 11 using gcc.  The first three of them also allow using Solaris Studio cc, which currently can't successfully finish the build.  Otherwise they should not affect other platforms, and they seem to be harmless on Linux (as in Travis), FreeBSD and OpenBSD.  Tested on latest snapshot of OpenIndiana (with gcc) and Oracle Solaris 11.3 (with gcc and Solaris Studio cc).

P.S.:  This is basically a cleaned up version of PR #21.
