### PR TITLE
Detect resolver API based on __RES version

### DIFF
--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -25,12 +25,12 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	uint32_t i;
 	int ret, err;
 
-#ifdef OPENBSD
-	ret = res_init();
-	state = _res;
-#else
+#if __RES >= 19980901
 	memset(&state, 0, sizeof(state));
 	ret = res_ninit(&state);
+#else
+	ret = res_init();
+	state = _res;
 #endif
 	if (0 != ret)
 		return ENOENT;
@@ -56,8 +56,7 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	*n = i;
 
  out:
-#ifdef OPENBSD
-#else
+#if __RES >= 19980901
 	res_nclose(&state);
 #endif
 

--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -59,6 +59,8 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
  out:
 #if __RES >= 19980901
 	res_nclose(&state);
+#elif !defined(OPENBSD)
+	res_close();
 #endif
 
 	return err;

--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -25,6 +25,7 @@ int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 	uint32_t i;
 	int ret, err;
 
+/* Reentrant API was introduced in BIND 8.2, which set __RES to 19980901. */
 #if __RES >= 19980901
 	memset(&state, 0, sizeof(state));
 	ret = res_ninit(&state);

--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <string.h>
 #include <unistd.h>
 #include <sys/ioctl.h>

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _BSD_SOURCE
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>


### PR DESCRIPTION
As BIND's `include/resolv.h` puts it:

> Revision information.  This is the release date in YYYYMMDD format.
> It can change every day so the right thing to do with it is use it
> in preprocessor commands such as "#if (__RES > 19931104)".  Do not
> compare for equality; rather, use it to determine whether your resolver
> is new enough to contain a certain feature.

Reentrant resolver API was introduced in BIND 8.2, which set `__RES` to `19980901`.
Thus, testing for

```
#if __RES >= 19980901
```

provides a reliable way to test for availability of reentrant resolver API.

In my testing this gives appropriate results across BSDs (FreeBSD, DragonFly BSD, NetBSD and OpenBSD), Linux with GNU and musl libc, Illumos and Solaris 11.  According to Travis, it builds without issues on macOS as well.  Of these platforms all but OpenBSD and Linux+musl provide reentrant resolver API _and_ define `__RES` to value higher then `19980901`.

If this change is not wanted for some reason, I would appreciate explanation.
