### PR TITLE
Change DTLS connection's remote peer address

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -78,4 +78,5 @@ int dtls_accept(struct tls_conn **ptc, struct tls *tls,
 int dtls_send(struct tls_conn *tc, struct mbuf *mb);
 void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
 		       dtls_recv_h *recvh, dtls_close_h *closeh, void *arg);
-bool dtls_set_peer(struct tls_conn *tc, const struct sa *peer);
+const struct sa *dtls_peer(const struct tls_conn *tc);
+void dtls_set_peer(struct tls_conn *tc, const struct sa *peer);

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -78,3 +78,4 @@ int dtls_accept(struct tls_conn **ptc, struct tls *tls,
 int dtls_send(struct tls_conn *tc, struct mbuf *mb);
 void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
 		       dtls_recv_h *recvh, dtls_close_h *closeh, void *arg);
+bool dtls_set_peer(struct tls_conn *tc, const struct sa *peer);

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -652,7 +652,7 @@ void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
 
 
 /**
- * Get the remote peer a DTLS Connection
+ * Get the remote peer of a DTLS Connection
  *
  * @param tc DTLS Connection
  *

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -651,6 +651,31 @@ void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
 }
 
 
+/**
+ * Set remote peer of a DTLS Connection
+ *
+ * @param tc     DTLS Connection
+ * @param peer   Peer address
+ *
+ * @return true if peer has been replaced, false if not
+ */
+bool dtls_set_peer(struct tls_conn *tc, const struct sa *peer)
+{
+	if (!tc || !peer)
+		return false;
+
+	if (!sa_cmp(&tc->peer, peer, SA_ALL)) {
+		hash_unlink(&tc->he);
+		hash_append(tc->sock->ht, sa_hash(peer, SA_ALL), &tc->he, tc);
+
+		tc->peer = *peer;
+		return true;
+	}
+
+	return false;
+}
+
+
 static void sock_destructor(void *arg)
 {
 	struct dtls_sock *sock = arg;

--- a/src/tls/openssl/tls_udp.c
+++ b/src/tls/openssl/tls_udp.c
@@ -652,27 +652,33 @@ void dtls_set_handlers(struct tls_conn *tc, dtls_estab_h *estabh,
 
 
 /**
- * Set remote peer of a DTLS Connection
+ * Get the remote peer a DTLS Connection
+ *
+ * @param tc DTLS Connection
+ *
+ * @return Remote peer
+ */
+const struct sa *dtls_peer(const struct tls_conn *tc)
+{
+	return tc ? &tc->peer : NULL;
+}
+
+
+/**
+ * Set the remote peer of a DTLS Connection
  *
  * @param tc     DTLS Connection
  * @param peer   Peer address
- *
- * @return true if peer has been replaced, false if not
  */
-bool dtls_set_peer(struct tls_conn *tc, const struct sa *peer)
+void dtls_set_peer(struct tls_conn *tc, const struct sa *peer)
 {
 	if (!tc || !peer)
-		return false;
+		return;
 
-	if (!sa_cmp(&tc->peer, peer, SA_ALL)) {
-		hash_unlink(&tc->he);
-		hash_append(tc->sock->ht, sa_hash(peer, SA_ALL), &tc->he, tc);
+	hash_unlink(&tc->he);
+	hash_append(tc->sock->ht, sa_hash(peer, SA_ALL), &tc->he, tc);
 
-		tc->peer = *peer;
-		return true;
-	}
-
-	return false;
+	tc->peer = *peer;
 }
 
 


### PR DESCRIPTION
These changes add the possibility to get and set the DTLS connection's remote peer address.

To make this possible, the following functions have been added:

```c
const struct sa *dtls_peer(const struct tls_conn *tc);
void dtls_set_peer(struct tls_conn *tc, const struct sa *peer);
```