### PR TITLE
mk: rules for making tarball (ref #31)

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -710,6 +710,16 @@ tar:
 		&& echo "created source tarball `pwd`/$(TAR_SRC).tar.gz"
 
 
+git_release:
+	git archive --format=tar --prefix=$(PROJECT)-$(VERSION)/ v$(VERSION) \
+		| gzip > ../$(PROJECT)-$(VERSION).tar.gz
+
+
+git_snapshot:
+	git archive --format=tar --prefix=$(PROJECT)-$(VERSION)/ HEAD \
+		| gzip > ../$(PROJECT)-$(VERSION).tar.gz
+
+
 # Debian
 .PHONY: deb
 deb:


### PR DESCRIPTION
this PR adds two new makefile rules for making a tarball from GIT projects
that include `re.mk`

* make git_release -- create a release tarball from a version tag (e.g. `v0.5.0`)
* make git_snapshot -- create a tarball from the current HEAD version.

@richaas please review and merge to master