### PR TITLE
tls: undef X509_NAME for win32 (fixes #32)

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -24,6 +24,12 @@
 #include "tls.h"
 
 
+/* also defined by wincrypt.h */
+#ifdef WIN32
+#undef X509_NAME
+#endif
+
+
 #define DEBUG_MODULE "tls"
 #define DEBUG_LEVEL 5
 #include <re_dbg.h>


### PR DESCRIPTION
this fixes https://github.com/creytiv/re/issues/32

another solution is to swap the inclusion of openssl and re header files,
as this would include windows headers first and then openssl headers
after that.
