### PR TITLE
Set Diffie-Hellman parameters

### DIFF
--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -54,6 +54,8 @@ int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
 		     uint8_t *srv_key, size_t srv_key_size);
 const char *tls_cipher_name(const struct tls_conn *tc);
 int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count);
+int tls_set_dh_params_pem(struct tls *tls, const char *pem, size_t len);
+int tls_set_dh_params_der(struct tls *tls, const uint8_t *der, size_t len);
 int tls_set_servername(struct tls_conn *tc, const char *servername);
 
 


### PR DESCRIPTION
Add the possibility to set Diffie-Hellman parameters for DH(E) and ECDH(E).

The following functions have been added:

* `tls_set_dh_params_pem` to read DH parameters from a PEM string
* `tls_set_dh_params_der` to read DH parameters from DER-encoded binary

When setting Diffie-Hellman parameters, those parameters will also be added for elliptic curve ciphers.
For older OpenSSL versions that do not support the `SSL_CTX_set_ecdh_auto` function, only the NIST P-256 curve is being enabled for ECDH(E).