### PR TITLE
update changelog for libre 0.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@
 # Master version number
 VER_MAJOR := 0
 VER_MINOR := 5
-VER_PATCH := 0
+VER_PATCH := 1
 
 PROJECT   := re
-VERSION   := 0.5.0
+VERSION   := 0.5.1
 
 MK	:= mk/re.mk
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ libre README
 
 
 libre is a Generic library for real-time communications with async IO support.
-Copyright (C) 2010 - 2016 Creytiv.com
+Copyright (C) 2010 - 2017 Creytiv.com
 
 
 [![Build Status](https://travis-ci.org/creytiv/re.svg?branch=master)](https://travis-ci.org/creytiv/re)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libre (0.5.1) unstable; urgency=medium
+
+  * version 0.5.1
+
+ -- Alfred E. Heggestad <alfred.heggestad@gmail.com>  Sat, 04 Feb 2017 12:00:00 +0100
+
 libre (0.5.0) unstable; urgency=medium
 
   * version 0.5.0

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,9 +3,9 @@ This package was debianized by Alfred E. Heggestad <aeh@db.org>
 It was downloaded from http://www.creytiv.com/
 
 
-Copyright (c) 2010 - 2016, Alfred E. Heggestad
-Copyright (c) 2010 - 2016, Richard Aas
-Copyright (c) 2010 - 2016, Creytiv.com
+Copyright (c) 2010 - 2017, Alfred E. Heggestad
+Copyright (c) 2010 - 2017, Richard Aas
+Copyright (c) 2010 - 2017, Creytiv.com
 All rights reserved.
 
 

--- a/docs/COPYING
+++ b/docs/COPYING
@@ -1,6 +1,6 @@
-Copyright (c) 2010 - 2016, Alfred E. Heggestad
-Copyright (c) 2010 - 2016, Richard Aas
-Copyright (c) 2010 - 2016, Creytiv.com
+Copyright (c) 2010 - 2017, Alfred E. Heggestad
+Copyright (c) 2010 - 2017, Richard Aas
+Copyright (c) 2010 - 2017, Creytiv.com
 All rights reserved.
 
 

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,3 +1,17 @@
+2017-02-04 Alfred E. Heggestad <alfred.heggestad@gmail.com>
+
+	* Version 0.5.1
+
+	* Project URL: https://github.com/creytiv/re
+
+	* fmt: print directly to stream using handler (#38)
+
+	* http: HTTP client improvements (#36)
+	  - http client connection reuse
+	  - retry failed requests using fresh connections
+	  - Handle Connection: close response header
+
+
 2016-11-25 Alfred E. Heggestad <alfred.heggestad@gmail.com>
 
 	* Version 0.5.0

--- a/rpm/re.spec
+++ b/rpm/re.spec
@@ -1,5 +1,5 @@
 %define name     re
-%define ver      0.5.0
+%define ver      0.5.1
 %define rel      1
 
 Summary: Generic library for real-time communications with async IO support


### PR DESCRIPTION
I would like to make a new release of libre version 0.5.1

the release date has been set to Saturday 4. Feb 2017

using retest and baresip the following platforms have been tested:

- Android NDK r13 (api 17)
- Arch Linux
- CentOS 7.3 x86_64
- Debian 6.0 i386
- Debian 7.11 x86_64
- Debian 8.7 i386
- Fedora 24 x86_64
- MacOSX v10.12 x86_64
- Mingw32 (Debian 7)
- OpenBSD 6.0 (amd64)
- Ubuntu 14.04 x86_64
- Ubuntu 16.04 x86_64

The following compilers have been tested with:

- clang 8.0.0
- gcc 4.2.1
- gcc 4.4.5
- gcc 4.7.2	
- gcc 4.8.4
- gcc 4.8.5	
- gcc 4.9.2
- gcc 4.9	
- gcc 5.4.0
- gcc 6.3.1

The following versions of OpenSSL has been tested with:

- OpenSSL 0.9.8o
- OpenSSL 1.0.1e-fips
- OpenSSL 1.0.1f
- OpenSSL 1.0.1t
- OpenSSL 1.0.2g
- OpenSSL 1.0.2j
- OpenSSL 1.0.2j-fips
- OpenSSL 1.1.0c
- LibreSSL 2.4.2

@richaas please merge to master
