### PR TITLE
srtcp: use unsigned 32-bit for encrypted bit

### DIFF
--- a/src/srtp/srtcp.c
+++ b/src/srtp/srtcp.c
@@ -34,7 +34,7 @@ int srtcp_encrypt(struct srtp *srtp, struct mbuf *mb)
 	struct comp *rtcp;
 	uint32_t ssrc;
 	size_t start;
-	int ep = 0;
+	uint32_t ep = 0;
 	int err;
 
 	if (!srtp || !mb)


### PR DESCRIPTION
the ep is left-shifted by 31-bits. If the size of int
is 4 bytes then the EP bit will end up in the top bit
which is also the sign bit.

it is safer and better to use an unsigned type here