### PR TITLE
[WIP] replacing plus delimeter

### DIFF
--- a/src/http/msg.c
+++ b/src/http/msg.c
@@ -143,6 +143,7 @@ int http_msg_decode(struct http_msg **msgp, struct mbuf *mb, bool req)
 {
 	struct pl b, s, e, name, scode;
 	const char *p, *cv;
+	char *cm, *cmPtr;
 	struct http_msg *msg;
 	bool comsep, quote;
 	enum http_hdrid id = HTTP_HDR_NONE;
@@ -184,14 +185,10 @@ int http_msg_decode(struct http_msg **msgp, struct mbuf *mb, bool req)
 		msg->scode = pl_u32(&scode);
 	}
 
-
-	char *cm;
-	int ec = pl_strdup(&cm, &msg->prm);
-	if ( ec ) {
+	if ( pl_strdup(&cm, &msg->prm) ) {
 		return EBADMSG;
 	}
 
-	char *cmPtr;
 	for (cmPtr = cm; *cmPtr != '\0'; cmPtr++){
 	  if (*cmPtr == '+') {
 		 	*cmPtr = ' ';

--- a/src/http/msg.c
+++ b/src/http/msg.c
@@ -184,6 +184,12 @@ int http_msg_decode(struct http_msg **msgp, struct mbuf *mb, bool req)
 		msg->scode = pl_u32(&scode);
 	}
 
+	char *rep = pl_strchr(&msg->prm, '+');
+	while(rep){
+		*rep = ' ';
+		rep = pl_strchr(&msg->prm, '+');
+	}
+
 	l -= e.p + e.l - p;
 	p = e.p + e.l;
 

--- a/src/http/msg.c
+++ b/src/http/msg.c
@@ -184,11 +184,20 @@ int http_msg_decode(struct http_msg **msgp, struct mbuf *mb, bool req)
 		msg->scode = pl_u32(&scode);
 	}
 
-	char *rep = pl_strchr(&msg->prm, '+');
-	while(rep){
-		*rep = ' ';
-		rep = pl_strchr(&msg->prm, '+');
+
+	char *cm;
+	int ec = pl_strdup(&cm, &msg->prm);
+	if( ec )
+		return EBADMSG;
+
+	char *cmPtr;
+	for (cmPtr = cm; *cmPtr != '\0'; cmPtr++){
+	  if(*cmPtr == '+')
+		 	*cmPtr = ' ';
 	}
+
+	pl_set_str(&msg->prm, cm);
+
 
 	l -= e.p + e.l - p;
 	p = e.p + e.l;

--- a/src/http/msg.c
+++ b/src/http/msg.c
@@ -187,13 +187,15 @@ int http_msg_decode(struct http_msg **msgp, struct mbuf *mb, bool req)
 
 	char *cm;
 	int ec = pl_strdup(&cm, &msg->prm);
-	if( ec )
+	if ( ec ) {
 		return EBADMSG;
+	}
 
 	char *cmPtr;
 	for (cmPtr = cm; *cmPtr != '\0'; cmPtr++){
-	  if(*cmPtr == '+')
+	  if (*cmPtr == '+') {
 		 	*cmPtr = ' ';
+		}
 	}
 
 	pl_set_str(&msg->prm, cm);


### PR DESCRIPTION
Implemented that the '+' symbol can be used as an 'space'. It is
replaced that commands that need a space can be used by http calls.

Baresip Example: http://0.0.0.0:8008/?/auplay+alsa,default

But I honestly doesn't now if this is according the intentions of baresip/libre.