### PR TITLE
tls: enable ECDH by default

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -209,6 +209,16 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	}
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+	r = SSL_CTX_set_ecdh_auto(tls->ctx, 1);
+	if (!r) {
+		DEBUG_WARNING("alloc: set_ecdh_auto failed (ret=%d)\n", r);
+		ERR_clear_error();
+		err = ENOTSUP;
+		goto out;
+	}
+#endif
+
 	err = 0;
  out:
 	if (err)


### PR DESCRIPTION
please dont merge yet.

this has been discussed in the past. Since openssl 1.1.0 enables this by default,
I think we should do the same. (ECDH = Elliptic Curve Diffie Hellmann).

testing:

```
Arch Linux	OpenSSL 1.0.2k		ECDHE-RSA-AES256-GCM-SHA384
Debian Testing	OpenSSL 1.1.0e		ECDHE-RSA-AES256-GCM-SHA384
Fedora 24	OpenSSL 1.0.2k-fips	ECDHE-RSA-AES256-GCM-SHA384
Mingw		OpenSSL 1.1.0e		ECDHE-RSA-AES256-GCM-SHA384
OSX 10.12	OpenSSL 1.0.2k		ECDHE-RSA-AES256-GCM-SHA384
OpenBSD 6.0	LibreSSL 2.4.2		ECDHE-RSA-AES256-GCM-SHA384
Ubuntu 16	OpenSSL 1.0.2g		ECDHE-RSA-AES256-GCM-SHA384
```
