### PR TITLE
include stdint.h to fix cross compilation on linux

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -5,6 +5,7 @@
  */
 
 #include <sys/types.h>
+#include <stdint.h>
 
 #ifdef _MSC_VER
 #include <stdlib.h>


### PR DESCRIPTION
I'm working on a yocto recipe for libre (as well as librem and baresip) and I'm getting compilation errors when targeting linux on arm:
re_types.h:57:9: error: unknown type name 'uint32_t'

This patch fixes that... though I'm not sure if its the best way of doing it to remain compatible on other platforms.