### PR TITLE
Handle %h prefixed (short) types

### DIFF
--- a/src/fmt/print.c
+++ b/src/fmt/print.c
@@ -299,6 +299,11 @@ int re_vhprintf(const char *fmt, va_list ap, re_vprintf_h *vph, void *arg)
 			}
 			break;
 
+		case 'h':
+			lenmod = LENMOD_NONE;
+			fm = true;
+			break;
+
 		case 'H':
 			ph     = va_arg(ap, re_printf_h *);
 			ph_arg = va_arg(ap, void *);


### PR DESCRIPTION
I noticed that the print output when using `PRIu16` for `uint16_t` failed on OSX with a segfault. Turns out that `PRIu16 = "hu"` on this platform and re cannot handle `%h<type>`.

Note that I haven't added a new `LENMOD_SHORT` because `short` will be promoted to `int` when using vararg functions.

I have also updated `retest` (PR following).