### PR TITLE
Make sampling rate for telephone events configurable

### DIFF
--- a/include/re_telev.h
+++ b/include/re_telev.h
@@ -13,7 +13,7 @@ struct telev;
 
 extern const char telev_rtpfmt[];
 
-int telev_alloc(struct telev **tp, uint32_t ptime, uint32_t srate);
+int telev_alloc(struct telev **tp, uint32_t ptime);
 int telev_set_srate(struct telev *tel, uint32_t srate);
 int telev_send(struct telev *tel, int event, bool end);
 int telev_recv(struct telev *tel, struct mbuf *mb, int *event, bool *end);

--- a/include/re_telev.h
+++ b/include/re_telev.h
@@ -13,7 +13,8 @@ struct telev;
 
 extern const char telev_rtpfmt[];
 
-int telev_alloc(struct telev **tp, uint32_t ptime);
+int telev_alloc(struct telev **tp, uint32_t ptime, uint32_t srate);
+int telev_set_srate(struct telev *tel, uint32_t srate);
 int telev_send(struct telev *tel, int event, bool end);
 int telev_recv(struct telev *tel, struct mbuf *mb, int *event, bool *end);
 int telev_poll(struct telev *tel, bool *marker, struct mbuf *mb);


### PR DESCRIPTION
For telephone events the same timestamp base as for audio is used. Thus the correct clock rate also has to
be taken into account for calculation of durations and needs to be configurable.