### PR TITLE
rtp: add extension bit to the api

### DIFF
--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -204,10 +204,10 @@ int   rtp_listen(struct rtp_sock **rsp, int proto, const struct sa *ip,
 		 rtp_recv_h *recvh, rtcp_recv_h *rtcph, void *arg);
 int   rtp_hdr_encode(struct mbuf *mb, const struct rtp_header *hdr);
 int   rtp_hdr_decode(struct rtp_header *hdr, struct mbuf *mb);
-int   rtp_encode(struct rtp_sock *rs, bool marker, uint8_t pt,
+int   rtp_encode(struct rtp_sock *rs, bool ext, bool marker, uint8_t pt,
 		 uint32_t ts, struct mbuf *mb);
 int   rtp_decode(struct rtp_sock *rs, struct mbuf *mb, struct rtp_header *hdr);
-int   rtp_send(struct rtp_sock *rs, const struct sa *dst,
+int   rtp_send(struct rtp_sock *rs, const struct sa *dst, bool ext,
 	       bool marker, uint8_t pt, uint32_t ts, struct mbuf *mb);
 int   rtp_debug(struct re_printf *pf, const struct rtp_sock *rs);
 void *rtp_sock(const struct rtp_sock *rs);

--- a/include/re_rtp.h
+++ b/include/re_rtp.h
@@ -204,11 +204,13 @@ int   rtp_listen(struct rtp_sock **rsp, int proto, const struct sa *ip,
 		 rtp_recv_h *recvh, rtcp_recv_h *rtcph, void *arg);
 int   rtp_hdr_encode(struct mbuf *mb, const struct rtp_header *hdr);
 int   rtp_hdr_decode(struct rtp_header *hdr, struct mbuf *mb);
-int   rtp_encode(struct rtp_sock *rs, bool ext, bool marker, uint8_t pt,
+int   rtp_encode(struct rtp_sock *rs, bool marker, uint8_t pt,
 		 uint32_t ts, struct mbuf *mb);
 int   rtp_decode(struct rtp_sock *rs, struct mbuf *mb, struct rtp_header *hdr);
-int   rtp_send(struct rtp_sock *rs, const struct sa *dst, bool ext,
+int   rtp_send(struct rtp_sock *rs, const struct sa *dst,
 	       bool marker, uint8_t pt, uint32_t ts, struct mbuf *mb);
+int   rtp_send_ext(struct rtp_sock *rs, const struct sa *dst, bool ext,
+		   bool marker, uint8_t pt, uint32_t ts, struct mbuf *mb);
 int   rtp_debug(struct re_printf *pf, const struct rtp_sock *rs);
 void *rtp_sock(const struct rtp_sock *rs);
 uint32_t rtp_sess_ssrc(const struct rtp_sock *rs);

--- a/src/rtp/rtp.c
+++ b/src/rtp/rtp.c
@@ -358,8 +358,8 @@ int rtp_listen(struct rtp_sock **rsp, int proto, const struct sa *ip,
  *
  * @note The buffer must have enough space for the RTP header
  */
-int rtp_encode(struct rtp_sock *rs, bool marker, uint8_t pt, uint32_t ts,
-	       struct mbuf *mb)
+int rtp_encode(struct rtp_sock *rs, bool ext, bool marker, uint8_t pt,
+	       uint32_t ts, struct mbuf *mb)
 {
 	struct rtp_header hdr;
 
@@ -368,7 +368,7 @@ int rtp_encode(struct rtp_sock *rs, bool marker, uint8_t pt, uint32_t ts,
 
 	hdr.ver  = RTP_VERSION;
 	hdr.pad  = false;
-	hdr.ext  = false;
+	hdr.ext  = ext;
 	hdr.cc   = 0;
 	hdr.m    = marker ? 1 : 0;
 	hdr.pt   = pt;
@@ -421,7 +421,7 @@ int rtp_decode(struct rtp_sock *rs, struct mbuf *mb,
  *
  * @return 0 for success, otherwise errorcode
  */
-int rtp_send(struct rtp_sock *rs, const struct sa *dst,
+int rtp_send(struct rtp_sock *rs, const struct sa *dst, bool ext,
 	     bool marker, uint8_t pt, uint32_t ts, struct mbuf *mb)
 {
 	size_t pos;
@@ -441,7 +441,7 @@ int rtp_send(struct rtp_sock *rs, const struct sa *dst,
 
 	pos = mb->pos;
 
-	err = rtp_encode(rs, marker, pt, ts, mb);
+	err = rtp_encode(rs, ext, marker, pt, ts, mb);
 	if (err)
 		return err;
 


### PR DESCRIPTION
this PR adds "bool ext" to the `rtp_send` function

currently the EXTENSION bit is always set to false in the RTP header.
setting the extension bit per packet is needed for e.g. RFC 5285

NOTE! This will break the api.

if breaking the api is not wanted, we could instead add a new function
for sending with EXT=true:

```
rtp_send_ext();
```

