### PR TITLE
Pack struct of mqueue messages.

### DIFF
--- a/src/mqueue/mqueue.c
+++ b/src/mqueue/mqueue.c
@@ -36,9 +36,9 @@ struct mqueue {
 };
 
 struct msg {
-	int id;
 	void *data;
 	uint32_t magic;
+	int id;
 };
 
 


### PR DESCRIPTION
Without the change, the `data` field is padded to the next 8 bytes boundary on 64 bit systems, resulting in `sizeof(struct msg)` to be 24 bytes and valgrind reporting uninitialized bytes:
```
==22350== Syscall param write(buf) points to uninitialised byte(s)
==22350==    at 0x5CB734D: ??? (syscall-template.S:81)
==22350==    by 0x948EFE: pipe_write (mqueue.h:21)
==22350==    by 0x949157: mqueue_push (mqueue.c:152)
```

After reordering the fields, the struct size is 16 bytes and no padding is required.