### PR TITLE
mod: add accessor function to module list

### DIFF
--- a/include/re_mod.h
+++ b/include/re_mod.h
@@ -71,4 +71,5 @@ int         mod_load(struct mod **mp, const char *name);
 int         mod_add(struct mod **mp, const struct mod_export *me);
 struct mod *mod_find(const char *name);
 const struct mod_export *mod_export(const struct mod *m);
+struct list *mod_list(void);
 int         mod_debug(struct re_printf *pf, void *unused);

--- a/src/mod/mod.c
+++ b/src/mod/mod.c
@@ -204,6 +204,17 @@ const struct mod_export *mod_export(const struct mod *m)
 
 
 /**
+ * Get the list of loaded modules
+ *
+ * @return Module list
+ */
+struct list *mod_list(void)
+{
+	return &modl;
+}
+
+
+/**
  * Debug loadable modules
  *
  * @param pf     Print handler for debug output


### PR DESCRIPTION
it is needed by e.g. baresip to traverse all modules and check
for specific name/type

please review and merge to master.

/Alfred