### PR TITLE
sipreg: add accessor function sipreg_laddr()

### DIFF
--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -13,3 +13,5 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 		    int regid, sip_auth_h *authh, void *aarg, bool aref,
 		    sip_resp_h *resph, void *arg,
 		    const char *params, const char *fmt, ...);
+
+const struct sa *sipreg_laddr(const struct sipreg *reg);

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -392,3 +392,16 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 
 	return err;
 }
+
+
+/**
+ * Get the local socket address for a SIP Registration client
+ *
+ * @param reg SIP Registration client
+ *
+ * @return Local socket address
+ */
+const struct sa *sipreg_laddr(const struct sipreg *reg)
+{
+	return reg ? &reg->laddr : NULL;
+}


### PR DESCRIPTION
Add accessor function in order to expose the IP address used in the Contact header URI  when registering. The same SIP URI will appear as the request URI of incoming requests.

@alfredh please review and merge