### PR TITLE
Add function to get the remote address of the selected candidate pair

### DIFF
--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -100,6 +100,7 @@ struct list *icem_checkl(const struct icem *icem);
 struct list *icem_validl(const struct icem *icem);
 const struct sa *icem_cand_default(struct icem *icem, unsigned compid);
 const struct sa *icem_selected_laddr(const struct icem *icem, unsigned compid);
+const struct sa *icem_selected_raddr(const struct icem *icem, unsigned compid);
 void ice_candpair_set_states(struct icem *icem);
 void icem_cand_redund_elim(struct icem *icem);
 int  icem_comps_set_default_cand(struct icem *icem);

--- a/src/ice/chklist.c
+++ b/src/ice/chklist.c
@@ -300,3 +300,21 @@ const struct sa *icem_selected_laddr(const struct icem *icem, unsigned compid)
 
 	return &comp->cp_sel->lcand->addr;
 }
+
+
+/**
+ * Get the Remote address of the Selected Candidate pair, if available
+ *
+ * @param icem   ICE Media object
+ * @param compid Component ID
+ *
+ * @return Remote address if available, otherwise NULL
+ */
+const struct sa *icem_selected_raddr(const struct icem *icem, unsigned compid)
+{
+	const struct icem_comp *comp = icem_comp_find(icem, compid);
+	if (!comp || !comp->cp_sel)
+		return NULL;
+
+	return &comp->cp_sel->rcand->addr;
+}


### PR DESCRIPTION
This matches the existing `icem_selected_laddr`.