### PR TITLE
ice: Added functions to get selected candidates.

### DIFF
--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -100,6 +100,10 @@ struct list *icem_checkl(const struct icem *icem);
 struct list *icem_validl(const struct icem *icem);
 const struct sa *icem_cand_default(struct icem *icem, unsigned compid);
 const struct sa *icem_selected_laddr(const struct icem *icem, unsigned compid);
+const struct ice_cand *icem_selected_lcand(const struct icem *icem,
+				unsigned compid);
+const struct ice_cand *icem_selected_rcand(const struct icem *icem,
+				unsigned compid);
 void ice_candpair_set_states(struct icem *icem);
 void icem_cand_redund_elim(struct icem *icem);
 int  icem_comps_set_default_cand(struct icem *icem);
@@ -119,6 +123,7 @@ int icem_lcand_add(struct icem *icem, struct ice_cand *base,
 		   const struct sa *addr);
 struct ice_cand *icem_lcand_base(struct ice_cand *lcand);
 const struct sa *icem_lcand_addr(const struct ice_cand *cand);
+enum ice_cand_type icem_cand_type(const struct ice_cand *cand);
 
 
 extern const char ice_attr_cand[];

--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -55,6 +55,7 @@ enum ice_candpair_state {
 };
 
 struct ice;
+struct ice_cand;
 struct icem;
 struct turnc;
 
@@ -112,7 +113,6 @@ int icem_set_turn_client(struct icem *icem, unsigned compid,
 			 struct turnc *turnc);
 
 
-struct ice_cand;
 bool ice_remotecands_avail(const struct icem *icem);
 int  ice_cand_encode(struct re_printf *pf, const struct ice_cand *cand);
 int  ice_remotecands_encode(struct re_printf *pf, const struct icem *icem);

--- a/src/ice/cand.c
+++ b/src/ice/cand.c
@@ -310,3 +310,8 @@ int icem_cand_print(struct re_printf *pf, const struct ice_cand *cand)
 
 	return err;
 }
+
+enum ice_cand_type icem_cand_type(const struct ice_cand *cand)
+{
+	return cand ? cand->type : (enum ice_cand_type)-1;
+}

--- a/src/ice/chklist.c
+++ b/src/ice/chklist.c
@@ -294,9 +294,44 @@ void icem_checklist_update(struct icem *icem)
  */
 const struct sa *icem_selected_laddr(const struct icem *icem, unsigned compid)
 {
+	const struct ice_cand *cand = icem_selected_lcand(icem, compid);
+	return icem_lcand_addr(cand);
+}
+
+
+/**
+ * Get the Local candidate of the Selected Candidate pair, if available
+ *
+ * @param icem   ICE Media object
+ * @param compid Component ID
+ *
+ * @return Local candidate if available, otherwise NULL
+ */
+const struct ice_cand *icem_selected_lcand(const struct icem *icem,
+		unsigned compid)
+{
 	const struct icem_comp *comp = icem_comp_find(icem, compid);
 	if (!comp || !comp->cp_sel)
 		return NULL;
 
-	return &comp->cp_sel->lcand->addr;
+	return comp->cp_sel->lcand;
+}
+
+
+/**
+ * Get the Remote candidate of the Selected Candidate pair, if available
+ *
+ * @param icem   ICE Media object
+ * @param compid Component ID
+ *
+ * @return Remote candidate if available, otherwise NULL
+ */
+const struct ice_cand *icem_selected_rcand(const struct icem *icem,
+		unsigned compid)
+{
+	const struct icem_comp *comp = icem_comp_find(icem, compid);
+	if (!comp || !comp->cp_sel)
+		return NULL;
+
+	return comp->cp_sel->rcand;
 }


### PR DESCRIPTION
Also added a function to get the type of a candidate. This can be used when
sending data to handle relay candidates, where data must be sent through the
TURN client.

This is a more flexible variant of what I did in #71.