### PR TITLE
Update ar flags; use deterministic mode

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -237,7 +237,7 @@ ifeq ($(OS),linux)
 	MOD_LFLAGS	+=
 	APP_LFLAGS	+= -rdynamic
 	AR		:= ar
-	AFLAGS		:= cru
+	AFLAGS		:= crD
 endif
 ifeq ($(OS),gnu)
 	CFLAGS		+= -fPIC -DGNU


### PR DESCRIPTION
In Debian 9 (stretch), the ar program in the binutils package is now configured with
`--enable-deterministic-archives`. This make deterministic default mode, opposite of previous behavior. When running ar on Debian 9 we then get the following warning:

```
  CC      build-x86_64/json/decode_odict.o
  CC      build-x86_64/json/encode.o
  LD      libre.so
  AR      libre.a
ar: `u' modifier ignored since `D' is the default (see `U')
```

This PR make ar always use deterministic mode (on linux). This change makes the archives reproducible; equal input will always result in binary equal archive. The alternative would be to add the `U` option and thus keep the old, non-deterministic behavior.

@alfredh, please review and commit.