### PR TITLE
odict: use int instead of enum to avoid vararg promotion

### DIFF
--- a/include/re_odict.h
+++ b/include/re_odict.h
@@ -38,7 +38,7 @@ size_t odict_count(const struct odict *o, bool nested);
 int odict_debug(struct re_printf *pf, const struct odict *o);
 
 int odict_entry_add(struct odict *o, const char *key,
-		    enum odict_type type, ...);
+		    int type, ...);
 void odict_entry_del(struct odict *o, const char *key);
 int odict_entry_debug(struct re_printf *pf, const struct odict_entry *e);
 

--- a/src/odict/entry.c
+++ b/src/odict/entry.c
@@ -38,7 +38,7 @@ static void destructor(void *arg)
 
 
 int odict_entry_add(struct odict *o, const char *key,
-		    enum odict_type type, ...)
+		    int type, ...)
 {
 	struct odict_entry *e;
 	va_list ap;


### PR DESCRIPTION
building libre with clang 3.9 gives a warning in odict:

```
$ make CC=clang-mp-3.9 
  CC      build-x86_64/odict/entry.o
src/odict/entry.c:60:15: warning: passing an object that undergoes default argument promotion to
      'va_start' has undefined behavior [-Wvarargs]
        va_start(ap, type);
                     ^
src/odict/entry.c:41:23: note: parameter of type 'enum odict_type' is declared here
                    enum odict_type type, ...)
                                    ^
1 warning generated.
```

It looks like the Github Travis build servers have changed to clang 3.9
so the building of libre is currently failing.

most of the vararg code in libre is using a pointer (e.g. const char *) or
`uint32_t` and this code does not give warnings.

perhaps there are other solutions?
