### PR TITLE
make target debclean: update to reflect recent debhelper changes

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -749,7 +749,8 @@ deb:
 debclean:
 	@rm -rf build-stamp configure-stamp debian/files debian/$(PROJECT) \
 		debian/lib$(PROJECT) debian/lib$(PROJECT)-dev debian/tmp \
-		debian/.debhelper debian/*.debhelper.log debian/*.substvars
+		debian/.debhelper debian/*.debhelper debian/*.debhelper.log \
+		debian/*.substvars
 
 # RPM
 RPM := $(shell [ -d /usr/src/rpm ] 2>/dev/null && echo "rpm")


### PR DESCRIPTION
It turns out that we need both debian/.debhelper and debian/*.debhelper