### PR TITLE
sip: configurable timer values

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -221,6 +221,13 @@ struct sip_contact {
 	enum sip_transp tp;
 };
 
+/** SIP Configuration */
+struct sip_conf {
+	uint32_t timer_t1;  /**< Transaction Timer T1 [ms] */
+	uint32_t timer_t2;  /**< Transaction Timer T2 [ms] */
+	uint32_t timer_t4;  /**< Transaction Timer T4 [ms] */
+};
+
 struct sip;
 struct sip_lsnr;
 struct sip_request;
@@ -253,6 +260,8 @@ int  sip_listen(struct sip_lsnr **lsnrp, struct sip *sip, bool req,
 int  sip_debug(struct re_printf *pf, const struct sip *sip);
 int  sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	      const struct sa *dst, struct mbuf *mb);
+void sip_conf_set(struct sip *sip, const struct sip_conf *conf);
+const struct sip_conf *sip_conf(const struct sip *sip);
 
 
 /* transport */
@@ -368,3 +377,21 @@ int sip_cseq_decode(struct sip_cseq *cseq, const struct pl *pl);
 int sip_keepalive_start(struct sip_keepalive **kap, struct sip *sip,
 			const struct sip_msg *msg, uint32_t interval,
 			sip_keepalive_h *kah, void *arg);
+
+
+static inline uint32_t sip_t1(const struct sip *sip)
+{
+	return sip_conf(sip)->timer_t1;
+}
+
+
+static inline uint32_t sip_t2(const struct sip *sip)
+{
+	return sip_conf(sip)->timer_t2;
+}
+
+
+static inline uint32_t sip_t4(const struct sip *sip)
+{
+	return sip_conf(sip)->timer_t4;
+}

--- a/src/sip/ctrans.c
+++ b/src/sip/ctrans.c
@@ -187,15 +187,15 @@ static void retransmit_handler(void *arg)
 	switch (ct->state) {
 
 	case TRYING:
-		timeout = MIN(SIP_T1<<ct->txc, SIP_T2);
+		timeout = MIN(sip_t1(ct->sip)<<ct->txc, sip_t2(ct->sip));
 		break;
 
 	case CALLING:
-		timeout = SIP_T1<<ct->txc;
+		timeout = sip_t1(ct->sip)<<ct->txc;
 		break;
 
 	case PROCEEDING:
-		timeout = SIP_T2;
+		timeout = sip_t2(ct->sip);
 		break;
 
 	default:
@@ -294,7 +294,7 @@ static bool response_handler(const struct sip_msg *msg, void *arg)
 				break;
 			}
 
-			tmr_start(&ct->tmr, SIP_T4, tmr_handler, ct);
+			tmr_start(&ct->tmr, sip_t4(ct->sip), tmr_handler, ct);
 			tmr_cancel(&ct->tmre);
 		}
 		break;
@@ -340,10 +340,11 @@ int sip_ctrans_request(struct sip_ctrans **ctp, struct sip *sip,
 	if (err)
 		goto out;
 
-	tmr_start(&ct->tmr, 64 * SIP_T1, tmr_handler, ct);
+	tmr_start(&ct->tmr, 64 * sip_t1(sip), tmr_handler, ct);
 
-	if (!sip_transp_reliable(ct->tp))
-		tmr_start(&ct->tmre, SIP_T1, retransmit_handler, ct);
+	if (!sip_transp_reliable(ct->tp)) {
+		tmr_start(&ct->tmre, sip_t1(sip), retransmit_handler, ct);
+	}
 
  out:
 	if (err)
@@ -370,7 +371,7 @@ int sip_ctrans_cancel(struct sip_ctrans *ct)
 	switch (ct->state) {
 
 	case PROCEEDING:
-		tmr_start(&ct->tmr, 64 * SIP_T1, tmr_handler, ct);
+		tmr_start(&ct->tmr, 64 * sip_t1(ct->sip), tmr_handler, ct);
 		break;
 
 	default:

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -20,6 +20,13 @@
 #include "sip.h"
 
 
+static const struct sip_conf conf_default = {
+	SIP_T1,
+	SIP_T2,
+	SIP_T4
+};
+
+
 static void destructor(void *arg)
 {
 	struct sip *sip = arg;
@@ -126,6 +133,7 @@ int sip_alloc(struct sip **sipp, struct dnsc *dnsc, uint32_t ctsz,
 	sip->dnsc  = mem_ref(dnsc);
 	sip->exith = exith;
 	sip->arg   = arg;
+	sip->conf  = conf_default;
 
  out:
 	if (err)
@@ -212,6 +220,37 @@ int sip_listen(struct sip_lsnr **lsnrp, struct sip *sip, bool req,
 	}
 
 	return 0;
+}
+
+
+/**
+ * Set SIP configuration object
+ *
+ * @param sip  SIP Stack instance
+ * @param conf SIP configuration
+ */
+void sip_conf_set(struct sip *sip, const struct sip_conf *conf)
+{
+	if (!sip || !conf)
+		return;
+
+	sip->conf = *conf;
+}
+
+
+/**
+ * Get SIP configuration object
+ *
+ * @param sip SIP Stack instance
+ *
+ * @return SIP configuration
+ */
+const struct sip_conf *sip_conf(const struct sip *sip)
+{
+	if (sip)
+		return &sip->conf;
+	else
+		return &conf_default;
 }
 
 

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -9,6 +9,7 @@ struct sip {
 	struct list transpl;
 	struct list lsnrl;
 	struct list reql;
+	struct sip_conf conf;
 	struct hash *ht_ctrans;
 	struct hash *ht_strans;
 	struct hash *ht_strans_mrg;

--- a/src/sip/strans.c
+++ b/src/sip/strans.c
@@ -161,8 +161,8 @@ static void retransmit_handler(void *arg)
 		       st->mb);
 
 	st->txc++;
-	tmr_start(&st->tmrg, MIN(SIP_T1<<st->txc, SIP_T2), retransmit_handler,
-		  st);
+	tmr_start(&st->tmrg, MIN(sip_t1(st->sip)<<st->txc, sip_t2(st->sip)),
+		  retransmit_handler, st);
 }
 
 
@@ -188,7 +188,7 @@ static bool ack_handler(struct sip *sip, const struct sip_msg *msg)
 			break;
 		}
 
-		tmr_start(&st->tmr, SIP_T4, tmr_handler, st);
+		tmr_start(&st->tmr, sip_t4(sip), tmr_handler, st);
 		tmr_cancel(&st->tmrg);
 		st->state = CONFIRMED;
 		break;
@@ -367,15 +367,15 @@ int sip_strans_reply(struct sip_strans **stp, struct sip *sip,
 			st->state = PROCEEDING;
 		}
 		else if (scode < 300) {
-			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
+			tmr_start(&st->tmr, 64 * sip_t1(sip), tmr_handler, st);
 			st->state = ACCEPTED;
 		}
 		else {
-			tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler, st);
+			tmr_start(&st->tmr, 64 * sip_t1(sip), tmr_handler, st);
 			st->state = COMPLETED;
 
 			if (!sip_transp_reliable(st->msg->tp))
-				tmr_start(&st->tmrg, SIP_T1,
+				tmr_start(&st->tmrg, sip_t1(sip),
 					  retransmit_handler, st);
 		}
 	}
@@ -385,8 +385,8 @@ int sip_strans_reply(struct sip_strans **stp, struct sip *sip,
 		}
 		else {
 			if (!sip_transp_reliable(st->msg->tp)) {
-				tmr_start(&st->tmr, 64 * SIP_T1, tmr_handler,
-					  st);
+				tmr_start(&st->tmr, 64 * sip_t1(sip),
+					  tmr_handler, st);
 				st->state = COMPLETED;
 			}
 			else {

--- a/src/sipsess/ack.c
+++ b/src/sipsess/ack.c
@@ -27,6 +27,7 @@ struct sipsess_ack {
 	struct mbuf *mb;
 	enum sip_transp tp;
 	uint32_t cseq;
+	struct sip *sip;
 };
 
 
@@ -61,7 +62,7 @@ static int send_handler(enum sip_transp tp, const struct sa *src,
 	ack->dst = *dst;
 	ack->tp  = tp;
 
-	tmr_start(&ack->tmr, 64 * SIP_T1, tmr_handler, ack);
+	tmr_start(&ack->tmr, 64 * sip_t1(ack->sip), tmr_handler, ack);
 
 	return 0;
 }
@@ -94,6 +95,7 @@ int sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
 
 	ack->dlg  = mem_ref(dlg);
 	ack->cseq = cseq;
+	ack->sip  = sock->sip;
 
 	err = sip_drequestf(&ack->req, sock->sip, false, "ACK", dlg, cseq,
 			    auth, send_handler, resp_handler, ack,

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -72,7 +72,8 @@ static void retransmit_handler(void *arg)
 		       &reply->msg->src, reply->mb);
 
 	reply->txc++;
-	tmr_start(&reply->tmrg, MIN(SIP_T1<<reply->txc, SIP_T2),
+	tmr_start(&reply->tmrg, MIN(sip_t1(reply->sess->sip)<<reply->txc,
+				    sip_t2(reply->sess->sip)),
 		  retransmit_handler, reply);
 }
 
@@ -116,8 +117,8 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	if (err)
 		goto out;
 
-	tmr_start(&reply->tmr, 64 * SIP_T1, tmr_handler, reply);
-	tmr_start(&reply->tmrg, SIP_T1, retransmit_handler, reply);
+	tmr_start(&reply->tmr, 64 * sip_t1(sess->sip), tmr_handler, reply);
+	tmr_start(&reply->tmrg, sip_t1(sess->sip), retransmit_handler, reply);
 
 	if (!mbuf_get_left(msg->mb) && desc) {
 		reply->awaiting_answer = true;


### PR DESCRIPTION
Add support for setting SIP Timers T1 T2 T4

use `sip_conf_set` to set the config
use `sip_conf` to get the config
