### PR TITLE
tls: use per connection bio_method (fixes issue #92)

### DIFF
--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -52,13 +52,6 @@ static void destructor(void *data)
 		X509_free(tls->cert);
 
 	mem_deref(tls->pass);
-
-#ifdef TLS_BIO_OPAQUE
-	if (tls->method_tcp)
-		BIO_meth_free(tls->method_tcp);
-	if (tls->method_udp)
-		BIO_meth_free(tls->method_udp);
-#endif
 }
 
 
@@ -199,15 +192,6 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 			goto out;
 		}
 	}
-
-#ifdef TLS_BIO_OPAQUE
-	tls->method_tcp = tls_method_tcp();
-	tls->method_udp = tls_method_udp();
-	if (!tls->method_tcp || !tls->method_udp) {
-		err = ENOMEM;
-		goto out;
-	}
-#endif
 
 	err = 0;
  out:

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -29,17 +29,7 @@ struct tls {
 	SSL_CTX *ctx;
 	X509 *cert;
 	char *pass;  /* password for private key */
-#ifdef TLS_BIO_OPAQUE
-	BIO_METHOD *method_tcp;
-	BIO_METHOD *method_udp;
-#endif
 };
-
-
-#ifdef TLS_BIO_OPAQUE
-BIO_METHOD *tls_method_tcp(void);
-BIO_METHOD *tls_method_udp(void);
-#endif
 
 
 void tls_flush_error(void);


### PR DESCRIPTION
This PR fixes the reported issue #92.

@alfredh, please test, review and merge.

I was not able to reproduce the restund issue on Debian stable (openssl 1.1.0f-3), so please verify with your Debian testing environment.