### PR TITLE
remove support for Cygwin

### DIFF
--- a/include/re_net.h
+++ b/include/re_net.h
@@ -3,10 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
-#ifdef CYGWIN
-#include <ws2tcpip.h>
-#include <winsock2.h>
-#elif defined(WIN32)
+#if defined(WIN32)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -339,16 +339,6 @@ ifeq ($(OS),win32)
 	BIN_SUFFIX	:= .exe
 	SYSROOT		:= /usr/$(MACHINE)/
 endif
-ifeq ($(OS),cygwin)
-	CFLAGS		+= -DCYGWIN -D_WIN32_WINNT=0x0501
-	LIBS		+= -lwsock32 -lws2_32
-	LFLAGS		+=
-	SH_LFLAGS	+= -shared
-	MOD_LFLAGS	+=
-	APP_LFLAGS	+= -Wl,-E
-	AR		:= ar
-	AFLAGS		:= cru
-endif
 
 CFLAGS	+= -DOS=\"$(OS)\"
 
@@ -603,10 +593,8 @@ CFLAGS  += -DHAVE_KQUEUE
 endif
 CFLAGS  += -DHAVE_UNAME
 CFLAGS  += -DHAVE_UNISTD_H
-ifneq ($(OS),cygwin)
 CFLAGS  += -DHAVE_STRINGS_H
 CFLAGS  += -DHAVE_GAI_STRERROR
-endif
 endif
 
 ifneq ($(HAVE_ARC4RANDOM),)

--- a/src/mod/dl.c
+++ b/src/mod/dl.c
@@ -13,9 +13,6 @@
 #define DEBUG_LEVEL 5
 #include <re_dbg.h>
 
-#ifdef CYGWIN
-#define RTLD_LOCAL   0
-#endif
 
 static const int dl_flag = RTLD_NOW | RTLD_LOCAL;
 

--- a/src/net/mod.mk
+++ b/src/net/mod.mk
@@ -15,9 +15,7 @@ SRCS	+= net/sockopt.c
 
 # Platform dependant files
 ifneq ($(OS),win32)
-ifneq ($(OS),cygwin)
 SRCS	+= net/posix/pif.c
-endif
 else
 SRCS	+= net/win32/wif.c
 endif

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -7,7 +7,7 @@
 #define _DEFAULT_SOURCE 1
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WIN32) && !defined(CYGWIN)
+#if !defined(WIN32)
 #define __USE_BSD 1  /**< Use BSD code */
 #include <unistd.h>
 #include <netdb.h>
@@ -66,7 +66,7 @@ int net_hostaddr(int af, struct sa *ip)
  */
 int net_default_source_addr_get(int af, struct sa *ip)
 {
-#if defined(WIN32) || defined(CYGWIN)
+#if defined(WIN32)
 	return net_hostaddr(af, ip);
 #else
 	char ifname[64] = "";

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -10,7 +10,7 @@
 #ifdef HAVE_IO_H
 #include <io.h>
 #endif
-#if !defined(WIN32) && !defined (CYGWIN)
+#if !defined(WIN32)
 #define __USE_POSIX 1  /**< Use POSIX flag */
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #define __USE_MISC 1

--- a/src/udp/udp.c
+++ b/src/udp/udp.c
@@ -10,7 +10,7 @@
 #ifdef HAVE_IO_H
 #include <io.h>
 #endif
-#if !defined(WIN32) && !defined (CYGWIN)
+#if !defined(WIN32)
 #define __USE_POSIX 1  /**< Use POSIX flag */
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #include <netdb.h>


### PR DESCRIPTION
The Cygwin platform is not supported any more.

This PR removes the last remnants of cygwin support.

When compiling libre on Linux, the libre.a static library is binary equal
before/after this patch (symbols stripped with strip -s ):

```
md5sum libre*.a
18645b6f51594fa853d2f2ef05dae13a  libre.a
18645b6f51594fa853d2f2ef05dae13a  libre_ref.a
```

@richaas Please review and merge to master.
