### PR TITLE
tmr: use clock_gettime() to avoid system clock drift

### DIFF
--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+
+#define _DEFAULT_SOURCE 1
 #include <string.h>
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -132,6 +134,26 @@ uint64_t tmr_jiffies(void)
 	li.LowPart = ft.dwLowDateTime;
 	li.HighPart = ft.dwHighDateTime;
 	jfs = li.QuadPart/10/1000;
+#elif HAVE_CLOCK_GETTIME
+
+	struct timespec now;
+	clockid_t clock_id;
+
+#if defined (CLOCK_MONOTONIC_RAW_APPROX)
+	clock_id = CLOCK_MONOTONIC_RAW_APPROX;
+#elif defined (CLOCK_BOOTTIME)
+	clock_id = CLOCK_BOOTTIME;
+#else
+	clock_id = CLOCK_MONOTONIC;
+#endif
+
+	if (0 != clock_gettime(clock_id, &now)) {
+		DEBUG_WARNING("jiffies: clock_gettime() failed (%m)\n", errno);
+		return 0;
+	}
+
+	jfs  = (long)now.tv_sec * (uint64_t)1000;
+	jfs += now.tv_nsec / (uint64_t)1000000;
 #else
 	struct timeval now;
 

--- a/src/tmr/tmr.c
+++ b/src/tmr/tmr.c
@@ -139,9 +139,7 @@ uint64_t tmr_jiffies(void)
 	struct timespec now;
 	clockid_t clock_id;
 
-#if defined (CLOCK_MONOTONIC_RAW_APPROX)
-	clock_id = CLOCK_MONOTONIC_RAW_APPROX;
-#elif defined (CLOCK_BOOTTIME)
+#if defined (CLOCK_BOOTTIME)
 	clock_id = CLOCK_BOOTTIME;
 #else
 	clock_id = CLOCK_MONOTONIC;


### PR DESCRIPTION
the current timer system is subject to adjusting the system clock.

1. for a pending timer, if the system clock is adjusted towards the future,
  the timer will trigger before it is supposed to trigger.

2. for a pending timer, if the system clock is adjusted towards the past,
  the timer will trigger later.

one solution to avoid this is to use `clock_gettime` for systems that support it:

```
 CLOCK_MONOTONIC

clock that increments monotonically, tracking the time since an arbitrary
point, and will continue to increment while the system is asleep.
```


https://linux.die.net/man/3/clock_gettime

Testing:

- [x] Debian Testing
- [x] OSX 10.12
- [x] Android NDK r14
- [x] OpenBSD 6.2
