### PR TITLE
net: larger buffer for net_if_list

### DIFF
--- a/src/net/win32/wif.c
+++ b/src/net/win32/wif.c
@@ -24,7 +24,7 @@
  */
 static int if_list_gaa(net_ifaddr_h *ifh, void *arg)
 {
-	IP_ADAPTER_ADDRESSES addrv[16], *cur;
+	IP_ADAPTER_ADDRESSES addrv[64], *cur;
 	ULONG ret, len = sizeof(addrv);
 	const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST;
 	HANDLE hLib;


### PR DESCRIPTION
when compiling with mingw32 and running in wine emulator,
I get this error when enumerating network interfaces:

    wif: if_list: GetAdaptersAddresses ret=111

use a large buffer for IP_ADAPTER_ADDRESSES fixes the error

this PR is another solution to this PR:

https://github.com/creytiv/re/pull/98

@richaas Please review and merge.
