### PR TITLE
Fix build with musl libc

### DIFF
--- a/src/dns/res.c
+++ b/src/dns/res.c
@@ -18,6 +18,12 @@
 #include <re_dns.h>
 #include "dns.h"
 
+#if defined(__linux__) && !defined(__GLIBC__) &&	\
+	!defined(__UCLIBC__) &&	!defined(__BIONIC__)
+/* Another popular libc for Linux offers OpenBSD's res_init() API */
+#define OPENBSD OPENBSD
+#endif
+
 
 int get_resolv_dns(char *domain, size_t dsize, struct sa *nsv, uint32_t *n)
 {

--- a/src/net/ifaddrs.c
+++ b/src/net/ifaddrs.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE
 #include <net/if.h>
 #include <ifaddrs.h>
 #include <re_types.h>

--- a/src/net/posix/pif.c
+++ b/src/net/posix/pif.c
@@ -11,6 +11,7 @@
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #include <netdb.h>
 #define __USE_MISC 1   /**< Use MISC code */
+#define _BSD_SOURCE
 #include <net/if.h>
 #include <arpa/inet.h>
 /*#include <net/if_arp.h>*/

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -14,6 +14,7 @@
 #define __USE_POSIX 1  /**< Use POSIX flag */
 #define __USE_XOPEN2K 1/**< Use POSIX.1:2001 code */
 #define __USE_MISC 1
+#define _BSD_SOURCE
 #include <netdb.h>
 #endif
 #ifdef __APPLE__


### PR DESCRIPTION
The other day i was trying to build re/baresip on Alpine Linux, which uses musl libc instead of glibc.

With a few small changes it builds just fine.

My only nitpick is one spot, where i had to work around the fact that musl-libc doesn't offer the reentrant res_ninit() API, and the code path for OpenBSD has to be taken instead.
Since musl considers #ifdef testing for libc variants evil, there is no `__MUSL__` macro to test against. I worked around it by testing for linux and absence of other libc's known to me, which is probably worse than what the musl devs intended to avoid.
I'm open to suggestions how to improve that.