### PR TITLE
mem: add secure memory functions

### DIFF
--- a/include/re_mem.h
+++ b/include/re_mem.h
@@ -37,3 +37,9 @@ void     mem_threshold_set(ssize_t n);
 struct re_printf;
 int      mem_status(struct re_printf *pf, void *unused);
 int      mem_get_stat(struct memstat *mstat);
+
+
+/* Secure memory functions */
+int  mem_seccmp(const volatile uint8_t *volatile s1,
+		const volatile uint8_t *volatile s2,
+		size_t n);

--- a/src/mem/mod.mk
+++ b/src/mem/mod.mk
@@ -5,3 +5,4 @@
 #
 
 SRCS	+= mem/mem.c
+SRCS	+= mem/secure.c

--- a/src/mem/secure.c
+++ b/src/mem/secure.c
@@ -27,7 +27,7 @@ int mem_seccmp(const volatile uint8_t *volatile s1,
 {
 	uint8_t val = 0;
 
-	if (!s1 || !s2 || !n)
+	if (!s1 || !s2)
 		return -1;
 
 	while (n--)

--- a/src/mem/secure.c
+++ b/src/mem/secure.c
@@ -1,0 +1,37 @@
+/**
+ * @file mem/secure.c  Secure memory functions
+ *
+ * Copyright (C) 2010 Creytiv.com
+ */
+
+#include <re_types.h>
+#include <re_mem.h>
+
+
+/**
+ * Compare two byte strings in constant time. This function can be used
+ * by secure code to compare secret data, such as authentication tags,
+ * to avoid side-channel attacks.
+ *
+ * @param s1 First byte string
+ * @param s2 Second byte string
+ * @param n  Number of bytes
+ *
+ * @return a negative number if argument errors
+ *         0 if both byte strings matching
+ *         a positive number if not matching
+ */
+int mem_seccmp(const volatile uint8_t *volatile s1,
+	       const volatile uint8_t *volatile s2,
+	       size_t n)
+{
+	uint8_t val = 0;
+
+	if (!s1 || !s2 || !n)
+		return -1;
+
+	while (n--)
+		val |= *s1++ ^ *s2++;
+
+	return val;
+}


### PR DESCRIPTION
the use case for these functions is secure code like
SRTP and TLS.

memcmp() should not be used when comparing secret data
such as shared keys, because the content may affect the timing.
instead the compare function should always take the same
to execute, independently of the content.