### PR TITLE
sip: add To name to sip_dialog_alloc

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -320,8 +320,8 @@ int  sip_contact_print(struct re_printf *pf,
 
 
 /* dialog */
-int  sip_dialog_alloc(struct sip_dialog **dlgp,
-		      const char *uri, const char *to_uri,
+int  sip_dialog_alloc(struct sip_dialog **dlgp, const char *uri,
+		      const char *to_name, const char *to_uri,
 		      const char *from_name, const char *from_uri,
 		      const char *routev[], uint32_t routec);
 int  sip_dialog_accept(struct sip_dialog **dlgp, const struct sip_msg *msg);

--- a/src/sip/dialog.c
+++ b/src/sip/dialog.c
@@ -78,6 +78,7 @@ static void destructor(void *arg)
  *
  * @param dlgp      Pointer to allocated SIP Dialog
  * @param uri       Target URI
+ * @param to_name   To displayname (optional)
  * @param to_uri    To URI
  * @param from_name From displayname (optional)
  * @param from_uri  From URI
@@ -86,10 +87,10 @@ static void destructor(void *arg)
  *
  * @return 0 if success, otherwise errorcode
  */
-int sip_dialog_alloc(struct sip_dialog **dlgp,
-		     const char *uri, const char *to_uri,
-		     const char *from_name, const char *from_uri,
-		     const char *routev[], uint32_t routec)
+int sip_dialog_alloc(struct sip_dialog **dlgp, const char *uri,
+		     const char *to_name, const char *to_uri,
+                     const char *from_name, const char *from_uri,
+                     const char *routev[], uint32_t routec)
 {
 	const uint64_t ltag = rand_u64();
 	struct sip_dialog *dlg;
@@ -132,7 +133,10 @@ int sip_dialog_alloc(struct sip_dialog **dlgp,
 		if (i == 0)
 			rend = dlg->mb->pos - 2;
 	}
-	err |= mbuf_printf(dlg->mb, "To: <%s>\r\n", to_uri);
+	err |= mbuf_printf(dlg->mb, "To: %s%s%s<%s>\r\n",
+			   to_name ? "\"" : "", to_name,
+			   to_name ? "\" " : "",
+			   to_uri);
 	dlg->cpos = dlg->mb->pos;
 	err |= mbuf_printf(dlg->mb, "From: %s%s%s<%s>;tag=%016llx\r\n",
 			   from_name ? "\"" : "", from_name,

--- a/src/sipevent/subscribe.c
+++ b/src/sipevent/subscribe.c
@@ -381,7 +381,7 @@ static int sipsub_alloc(struct sipsub **subp, struct sipevent_sock *sock,
 		sub->dlg = mem_ref(dlg);
 	}
 	else {
-		err = sip_dialog_alloc(&sub->dlg, uri, uri, from_name,
+		err = sip_dialog_alloc(&sub->dlg, uri, NULL, uri, from_name,
 				       from_uri, routev, routec);
 		if (err)
 			goto out;

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -340,7 +340,8 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 	if (!reg)
 		return ENOMEM;
 
-	err = sip_dialog_alloc(&reg->dlg, reg_uri, to_uri, NULL, from_uri,
+	err = sip_dialog_alloc(&reg->dlg, reg_uri,
+			       NULL, to_uri, NULL, from_uri,
 			       routev, routec);
 	if (err)
 		goto out;

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -222,8 +222,8 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 	sess->owner = true;
 
-	err = sip_dialog_alloc(&sess->dlg, to_uri, to_uri, from_name,
-			       from_uri, routev, routec);
+	err = sip_dialog_alloc(&sess->dlg, to_uri, NULL, to_uri, from_name,
+                               from_uri, routev, routec);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
 The usecase here is to be able to specify the To-header Display name.

Example message from SIP RFC:

```
       REGISTER sip:registrar.biloxi.com SIP/2.0
       Via: SIP/2.0/UDP bobspc.biloxi.com:5060;branch=z9hG4bKnashds7
       Max-Forwards: 70
       To: Bob <sip:bob@biloxi.com>
       From: Bob <sip:bob@biloxi.com>;tag=456248
       Call-ID: 843817637684230@998sdasdh09
       CSeq: 1826 REGISTER
       Contact: <sip:bob@192.0.2.4>
       Expires: 7200
       Content-Length: 0
```
