### PR TITLE
Allow API users to override the target of an in-dialog message

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -281,6 +281,11 @@ int sip_drequestf(struct sip_request **reqp, struct sip *sip, bool stateful,
 		  const char *met, struct sip_dialog *dlg, uint32_t cseq,
 		  struct sip_auth *auth, sip_send_h *sendh, sip_resp_h *resph,
 		  void *arg, const char *fmt, ...);
+int sip_drequestf_targeted(struct sip_request **reqp, struct sip *sip,
+		  bool stateful, const char *met, struct sip_dialog *dlg,
+		  const struct uri *route, uint32_t cseq,
+		  struct sip_auth *auth, sip_send_h *sendh, sip_resp_h *resph,
+		  void *arg, const char *fmt, ...);
 void sip_request_cancel(struct sip_request *req);
 bool sip_request_loops(struct sip_loopstate *ls, uint16_t scode);
 void sip_loopstate_reset(struct sip_loopstate *ls);
@@ -336,6 +341,7 @@ bool sip_dialog_established(const struct sip_dialog *dlg);
 bool sip_dialog_cmp(const struct sip_dialog *dlg, const struct sip_msg *msg);
 bool sip_dialog_cmp_half(const struct sip_dialog *dlg,
 			 const struct sip_msg *msg);
+const struct uri *sip_dialog_route(const struct sip_dialog *dlg);
 
 
 /* msg */

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -749,8 +749,10 @@ int dnsc_query(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 	       uint16_t type, uint16_t dnsclass,
 	       bool rd, dns_query_h *qh, void *arg)
 {
-	if (!dnsc)
+	if (!dnsc) {
+		DEBUG_WARNING("DNS query attempted but DNS client is unconfigured\n");
 		return EINVAL;
+	}
 
 	return query(qp, dnsc, DNS_OPCODE_QUERY, name, type, dnsclass, NULL,
 		     IPPROTO_UDP, dnsc->srvv, &dnsc->srvc, false, rd, qh, arg);


### PR DESCRIPTION
Hi,

In our application, we have reasonably sophisticated DNS requirements, so we're trying to avoid using re's built-in DNS, doing DNS resolving ourselves, and just passing re the IP addresses/ports to use.

In order to do this for in-dialog requests, we found we needed to add some methods:

- exposing the Route header on a dialog (learned from Record-Route) so we can resolve it
- a `sip_drequestf_targeted` alternative to `sip_drequestf`, which lets us specify a target rather than relying on the dialog route

I've also added a warning when we try to do DNS resolution with no DNS client, as this is tricky to diagnose otherwise.