### PR TITLE
Changed mechanics of choosing network adapter for Windows

### DIFF
--- a/include/re_net.h
+++ b/include/re_net.h
@@ -46,7 +46,6 @@ struct sa;
 
 
 /* Net generic */
-int  net_hostaddr(int af, struct sa *ip);
 int  net_default_source_addr_get(int af, struct sa *ip);
 int  net_default_gateway_get(int af, struct sa *gw);
 


### PR DESCRIPTION
Hello
If there are two or more network adapters installed in the system then re will connect to first adapter.
This adapter can be, for example, a virtual adapter or etc. Sometimes this leads to the fact that there is no connection between the re and the server.

I've renamed _net_hostaddr()_ to _net_hostaddr_win32()_ because it affects only Windows.

Previously _net_hostaddr()_ was using _gethostbyname()_. Now it is deprecated and it's better to use _GetAddrInfo()_, _GetAddrInfoA()_ or _GetAddrInfoB()_

Now _net_hostaddr_win32()_ is getting ip and address family of all adapters installed in the system. Then it checks which address family is matching with _af_.
`static int net_hostaddr_win32(int af, struct sa *ip)`
If match was found then it executing _sa_set_in()_