### PR TITLE
json/utf8: fix unescaping of unicode code points

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -144,3 +144,4 @@ void fmt_param_apply(const struct pl *pl, fmt_param_h *ph, void *arg);
 /* unicode */
 int utf8_encode(struct re_printf *pf, const char *str);
 int utf8_decode(struct re_printf *pf, const struct pl *pl);
+size_t utf8_byteseq(char u[4], unsigned cp);


### PR DESCRIPTION
Unicode code points above U+007F are currently not unescaped correctly. This patch fixes that, so that all code points (U+0000 - U+10FFFF) are properly unescaped in UTF-8 format.

@alfredh please review, test and merge.