### PR TITLE
Inline C++ issue fix for MSVC

### DIFF
--- a/include/re_types.h
+++ b/include/re_types.h
@@ -93,7 +93,9 @@ typedef bool _Bool;
 
 /* Needed for MS compiler */
 #ifdef _MSC_VER
+#ifndef __cplusplus
 #define inline _inline
+#endif
 #endif
 
 


### PR DESCRIPTION
See https://github.com/creytiv/re/issues/140. Tested on Visual Studio 2017, would be great if someone can test for older VC versions. This article https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2013/z8y1yy88(v=vs.120) indicates that even in old version, the inline was available for C++, only issue is with C code, because of pure historical support of C99. By the way this has changed and it now supports inline as well, so the commit could be improved by checking for specific version of _MSC_VER < X (I don't know minimal possible X though), but it is not needed.