### PR TITLE
net: sa_cmp returns true for match

### DIFF
--- a/src/net/if.c
+++ b/src/net/if.c
@@ -33,7 +33,7 @@ static bool if_getname_handler(const char *ifname, const struct sa *sa,
 	if (ife->af != sa_af(sa))
 		return false;
 
-	if (0 == sa_cmp(sa, ife->ip, SA_ADDR)) {
+	if (sa_cmp(sa, ife->ip, SA_ADDR)) {
 		str_ncpy(ife->ifname, ifname, ife->sz);
 		ife->found = true;
 		return true;


### PR DESCRIPTION
there is a bug in the networking code where the wrong interface name
is picked when resolving from IP-address to Interface name.

this is because `sa_cmp` is checked for 0 instead of `true`.

@richaas please review and merge to master.
