### PR TITLE
sip: get local TCP address in establish handler

### DIFF
--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -459,6 +459,8 @@ static void tcp_estab_handler(void *arg)
 	struct le *le;
 	int err;
 
+	tcp_conn_local_get(conn->tc, &conn->laddr);
+
 	conn->established = true;
 
 	le = list_head(&conn->ql);

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -459,7 +459,9 @@ static void tcp_estab_handler(void *arg)
 	struct le *le;
 	int err;
 
+#ifdef WIN32
 	tcp_conn_local_get(conn->tc, &conn->laddr);
+#endif
 
 	conn->established = true;
 


### PR DESCRIPTION
after calling tcp_connect(), the address returned by
tcp_conn_local_get() is 0.0.0.0 on some platforms (Windows).

the local address of the TCP-connection is not available
until the TCP connection is fully established, so fetch the
address again in the established handler.

Reference: https://github.com/alfredh/baresip/issues/431