### PR TITLE
Put intermediate build files in BUILD directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ MKDIR   := $(PREFIX)/share/re
 CFLAGS	+= -Iinclude
 
 MODMKS	:= $(patsubst %,src/%/mod.mk,$(MODULES))
-SHARED  := libre$(LIB_SUFFIX)
-STATIC	:= libre.a
+SHARED  := $(BUILD)/libre$(LIB_SUFFIX)
+STATIC	:= $(BUILD)/libre.a
+PKG-CONFIG := $(BUILD)/libre.pc
 
 include $(MODMKS)
 
@@ -74,19 +75,19 @@ ifneq ($(RANLIB),)
 	@$(RANLIB) $@
 endif
 
-libre.pc:
-	@echo 'prefix='$(PREFIX) > libre.pc
-	@echo 'exec_prefix=$${prefix}' >> libre.pc
-	@echo 'libdir=$${prefix}/lib' >> libre.pc
-	@echo 'includedir=$${prefix}/include/re' >> libre.pc
-	@echo '' >> libre.pc
-	@echo 'Name: libre' >> libre.pc
-	@echo 'Description: ' >> libre.pc
-	@echo 'Version: '$(VERSION) >> libre.pc
-	@echo 'URL: http://creytiv.com/re.html' >> libre.pc
-	@echo 'Libs: -L$${libdir} -lre' >> libre.pc
-	@echo 'Libs.private: -L$${libdir} -lre ${LIBS}' >> libre.pc
-	@echo 'Cflags: -I$${includedir}' >> libre.pc
+$(PKG-CONFIG):
+	@echo 'prefix='$(PREFIX) > $(PKG-CONFIG)
+	@echo 'exec_prefix=$${prefix}' >> $(PKG-CONFIG)
+	@echo 'libdir=$${prefix}/lib' >> $(PKG-CONFIG)
+	@echo 'includedir=$${prefix}/include/re' >> $(PKG-CONFIG)
+	@echo '' >> $(PKG-CONFIG)
+	@echo 'Name: libre' >> $(PKG-CONFIG)
+	@echo 'Description: ' >> $(PKG-CONFIG)
+	@echo 'Version: '$(VERSION) >> $(PKG-CONFIG)
+	@echo 'URL: http://creytiv.com/re.html' >> $(PKG-CONFIG)
+	@echo 'Libs: -L$${libdir} -lre' >> $(PKG-CONFIG)
+	@echo 'Libs.private: -L$${libdir} -lre ${LIBS}' >> $(PKG-CONFIG)
+	@echo 'Cflags: -I$${includedir}' >> $(PKG-CONFIG)
 
 $(BUILD)/%.o: src/%.c $(BUILD) Makefile $(MK) $(MODMKS)
 	@echo "  CC      $@"
@@ -100,17 +101,17 @@ $(BUILD): Makefile $(MK) $(MODMKS)
 
 .PHONY: clean
 clean:
-	@rm -rf $(SHARED) $(STATIC) libre.pc test.d test.o test $(BUILD)
+	@rm -rf $(SHARED) $(STATIC) $(PKG-CONFIG) test.d test.o test $(BUILD)
 
 
-install: $(SHARED) $(STATIC) libre.pc
+install: $(SHARED) $(STATIC) $(PKG-CONFIG)
 	@mkdir -p $(DESTDIR)$(LIBDIR) $(DESTDIR)$(LIBDIR)/pkgconfig \
 		$(DESTDIR)$(INCDIR) $(DESTDIR)$(MKDIR)
 	$(INSTALL) -m 0644 $(shell find include -name "*.h") \
 		$(DESTDIR)$(INCDIR)
 	$(INSTALL) -m 0755 $(SHARED) $(DESTDIR)$(LIBDIR)
 	$(INSTALL) -m 0755 $(STATIC) $(DESTDIR)$(LIBDIR)
-	$(INSTALL) -m 0644 libre.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+	$(INSTALL) -m 0644 $(PKG-CONFIG) $(DESTDIR)$(LIBDIR)/pkgconfig
 	$(INSTALL) -m 0644 $(MK) $(DESTDIR)$(MKDIR)
 
 uninstall:

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -205,7 +205,7 @@ endif
 
 
 ifneq ($(strip $(filter i386-mingw32 i486-mingw32 i586-mingw32msvc \
-	i686-w64-mingw32 mingw32, \
+	i686-w64-mingw32 x86_64-w64-mingw32 mingw32, \
 	$(MACHINE))),)
 	OS   := win32
 ifeq ($(MACHINE), mingw32)


### PR DESCRIPTION
I've changed Makefile to put resulted libre.a, libre.so and libre.pc in output BUILD directory. It is very useful during cross-compilation for different architectures. And it is common for all libraries with Makefiles.