### PR TITLE
release 0.5.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@
 # Master version number
 VER_MAJOR := 0
 VER_MINOR := 5
-VER_PATCH := 8
+VER_PATCH := 9
 
 PROJECT   := re
-VERSION   := 0.5.8
+VERSION   := 0.5.9
 
 MK	:= mk/re.mk
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libre (0.5.9) unstable; urgency=medium
+
+  * version 0.5.9
+
+ -- Alfred E. Heggestad <alfred.heggestad@gmail.com>  Sat, 1 Sep 2018 10:00:00 +0200
+
 libre (0.5.8) unstable; urgency=medium
 
   * version 0.5.8

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,3 +1,26 @@
+2018-09-01 Alfred E. Heggestad <alfred.heggestad@gmail.com>
+
+	* Version 0.5.9
+
+	* Project URL: https://github.com/creytiv/re
+
+	* build: Added support for 64-bit MINGW (#131)
+		 (thanks Alexander Ushakov)
+
+		 fixed inline issue when compiling VS as C++ (#143)
+		 (thanks TheSil)
+
+	* jbuf: zero out jbuf_stat on jbuf flush (#147)
+		(thanks Christian Spielberger)
+
+	* net: remove net_conn api (old and unused) (#145)
+	       fix bug in net_if_getname (#144)
+
+	* sip: get local TCP address in establish handler (#146)
+
+	* tls: add AES-GCM to DTLS-SRTP (#141)
+
+
 2018-04-20 Alfred E. Heggestad <alfred.heggestad@gmail.com>
 
 	* Version 0.5.8

--- a/rpm/re.spec
+++ b/rpm/re.spec
@@ -1,5 +1,5 @@
 %define name     re
-%define ver      0.5.8
+%define ver      0.5.9
 %define rel      1
 
 Summary: Generic library for real-time communications with async IO support


### PR DESCRIPTION
This is a proposal to release libre version 0.5.9

Suggested release date is set to Saturday 1. September 2018
