### PR TITLE
sip: Avoid function sip_addr_decode to clear uri-parameters.

### DIFF
--- a/src/sip/addr.c
+++ b/src/sip/addr.c
@@ -41,11 +41,13 @@ int sip_addr_decode(struct sip_addr *addr, const struct pl *pl)
 			addr->params.p = NULL;
 	}
 	else {
+		struct pl params;
 		memset(addr, 0, sizeof(*addr));
 
 		if (re_regex(pl->p, pl->l, "[^;]+[^]*",
-			     &addr->auri, &addr->params))
+			     &addr->auri, &params))
 			return EBADMSG;
+		addr->auri = *pl;
 	}
 
 	err = uri_decode(&addr->uri, &addr->auri);


### PR DESCRIPTION
The function sip_addr_decode has two branches. One for SIP addresses with angle brackets, like

Alice <sip:alice@atlanta.com>

and one for addresses without angle brackets, like

sip:alice@atlanta.com


But what if we need some URI parameters, like:

Alice \<sip:alice@atlanta.com;transport=tcp\>

or

sip:alice@atlanta.com;transport=tcp


Then the parameters are decoded to different places. In the first branch, they will be part of addr->auri. And addr->params is empty. Also addr->uri.params will contain the parameters.

In the second branch the address is split at the ';'. The addr->auri will NOT contain the parameters. Neither addr->uri.params.

RFC 3261: 
Page 222 tells me that transport=tcp is an uri-parameter. But section 20.10 specifies that if no angle brackets are present transport=tcp is a header parameter. This makes no sense for me.

The libre/baresip code tells me the truth. And I think this is that in call->peer_uri the parameters (e.g. transport=tcp) should be contained. See
function call_connect, where sip_addr_decode is used.

Currently calling "sip:alice@atlanta.com;transport=tcp" will not work correctly and UDP is used as transport protocol.

Regards,c.