### PR TITLE
Handle EPOLLHUP

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -784,7 +784,7 @@ static int fd_poll(struct re *re)
 				flags |= FD_READ;
 			if (re->events[i].events & EPOLLOUT)
 				flags |= FD_WRITE;
-			if (re->events[i].events & EPOLLERR)
+			if (re->events[i].events & (EPOLLERR|EPOLLHUP))
 				flags |= FD_EXCEPT;
 
 			if (!flags) {


### PR DESCRIPTION
I've used `fd_listen` for a pipe a while ago and encountered that `EPOLLHUP` was not handled. This PR raises `FD_EXCEPT` in case the `EPOLLHUP` event is being catched.

I have since removed the code that used the pipe from my code but thought this might still be a useful addition.