### PR TITLE
rtmp: handle both IPv4 and IPv6 uris

### DIFF
--- a/include/re_uri.h
+++ b/include/re_uri.h
@@ -23,6 +23,8 @@ typedef int (uri_apply_h)(const struct pl *name, const struct pl *val,
 struct re_printf;
 int  uri_encode(struct re_printf *pf, const struct uri *uri);
 int  uri_decode(struct uri *uri, const struct pl *pl);
+int  uri_decode_hostport(const struct pl *hostport, struct pl *host,
+			 struct pl *port);
 int  uri_param_get(const struct pl *pl, const struct pl *pname,
 		   struct pl *pvalue);
 int  uri_params_apply(const struct pl *pl, uri_apply_h *ah, void *arg);

--- a/src/rtmp/conn.c
+++ b/src/rtmp/conn.c
@@ -792,9 +792,8 @@ int rtmp_connect(struct rtmp_conn **connp, struct dnsc *dnsc, const char *uri,
 		return EINVAL;
 
 	if (re_regex(uri, strlen(uri), "rtmp://[^/]+/[^/]+/[^]+",
-		     &pl_hostport, &pl_app, &pl_stream)) {
+		     &pl_hostport, &pl_app, &pl_stream))
 		return EINVAL;
-	}
 
 	if (uri_decode_hostport(&pl_hostport, &pl_host, &pl_port))
 		return EINVAL;

--- a/src/uri/uri.c
+++ b/src/uri/uri.c
@@ -83,6 +83,9 @@ int uri_encode(struct re_printf *pf, const struct uri *uri)
 int uri_decode_hostport(const struct pl *hostport, struct pl *host,
 			struct pl *port)
 {
+	if (!hostport || !host || !port)
+		return EINVAL;
+
 	/* Try IPv6 first */
 	if (!re_regex(hostport->p, hostport->l, "\\[[0-9a-f:]+\\][:]*[0-9]*",
 		      host, NULL, port))

--- a/src/uri/uri.c
+++ b/src/uri/uri.c
@@ -74,10 +74,14 @@ int uri_encode(struct re_printf *pf, const struct uri *uri)
 /**
  * Decode host-port portion of a URI (if present)
  *
+ * @param hostport Host and port input string
+ * @param host     Decoded host portion
+ * @param port     Decoded port portion
+ *
  * @return 0 if success, otherwise errorcode
  */
-static int decode_hostport(const struct pl *hostport, struct pl *host,
-			   struct pl *port)
+int uri_decode_hostport(const struct pl *hostport, struct pl *host,
+			struct pl *port)
 {
 	/* Try IPv6 first */
 	if (!re_regex(hostport->p, hostport->l, "\\[[0-9a-f:]+\\][:]*[0-9]*",
@@ -114,7 +118,7 @@ int uri_decode(struct uri *uri, const struct pl *pl)
 			  &uri->scheme, &uri->user, NULL, &uri->password,
 			  &hostport, &uri->params, &uri->headers)) {
 
-		if (0 == decode_hostport(&hostport, &uri->host, &port))
+		if (0 == uri_decode_hostport(&hostport, &uri->host, &port))
 			goto out;
 	}
 
@@ -122,7 +126,7 @@ int uri_decode(struct uri *uri, const struct pl *pl)
 	err = re_regex(pl->p, pl->l, "[^:]+:[^;? ]+[^?]*[^]*",
 		       &uri->scheme, &hostport, &uri->params, &uri->headers);
 	if (0 == err) {
-		err = decode_hostport(&hostport, &uri->host, &port);
+		err = uri_decode_hostport(&hostport, &uri->host, &port);
 		if (0 == err)
 			goto out;
 	}


### PR DESCRIPTION
this PR adds support for IPv6 uris.

after this PR the following URI types should be supported:

* IPv4 address
* IPv6 address
* FQDN domain name

Example URI:

 * rtmp://example.com/vod/mp4:sample.mp4
 * rtmp://127.0.0.1/vod/mp4:sample.mp4
 * rtmp://[::1]/vod/mp4:sample.mp4

The IPv6 address must be encapsulated in square brackets `[]` similar
to other protocols such as SIP.
