### PR TITLE
Rtmp dechunk fix

### DIFF
--- a/src/rtmp/dechunk.c
+++ b/src/rtmp/dechunk.c
@@ -199,21 +199,11 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 				return ENOMEM;
 
 			if (chunk->hdr.format == 0) {
-
 				chunk->hdr.timestamp_delta =
 					chunk->hdr.timestamp;
-				chunk->hdr.timestamp +=
-					chunk->hdr.timestamp_delta;
 			}
-			else if (chunk->hdr.format == 1 ||
-				 chunk->hdr.format == 2) {
 
-				chunk->hdr.timestamp +=
-					chunk->hdr.timestamp_delta;
-			}
-			else {
-				return EPROTO;
-			}
+			chunk->hdr.timestamp += chunk->hdr.timestamp_delta;
 		}
 
 		left = mbuf_get_space(chunk->mb);

--- a/src/rtmp/dechunk.c
+++ b/src/rtmp/dechunk.c
@@ -192,8 +192,14 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 		break;
 
 	case 3:
-		if (!chunk->mb)
-			return EPROTO;
+		if (!chunk->mb) {
+
+			chunk->mb = mbuf_alloc(chunk->hdr.length);
+			if (!chunk->mb)
+				return ENOMEM;
+
+			chunk->hdr.timestamp += chunk->hdr.timestamp_delta;
+		}
 
 		left = mbuf_get_space(chunk->mb);
 

--- a/src/rtmp/dechunk.c
+++ b/src/rtmp/dechunk.c
@@ -198,7 +198,22 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 			if (!chunk->mb)
 				return ENOMEM;
 
-			chunk->hdr.timestamp += chunk->hdr.timestamp_delta;
+			if (chunk->hdr.format == 0) {
+
+				chunk->hdr.timestamp_delta =
+					chunk->hdr.timestamp;
+				chunk->hdr.timestamp +=
+					chunk->hdr.timestamp_delta;
+			}
+			else if (chunk->hdr.format == 1 ||
+				 chunk->hdr.format == 2) {
+
+				chunk->hdr.timestamp +=
+					chunk->hdr.timestamp_delta;
+			}
+			else {
+				return EPROTO;
+			}
 		}
 
 		left = mbuf_get_space(chunk->mb);

--- a/src/rtmp/dechunk.c
+++ b/src/rtmp/dechunk.c
@@ -143,8 +143,6 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 			return ENOENT;
 	}
 
-	/* only types 0-2 can create a new buffer */
-
 	switch (hdr.format) {
 
 	case 0:
@@ -220,6 +218,9 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 		chunk->mb->pos += chunk_sz;
 		chunk->mb->end += chunk_sz;
 		break;
+
+	default:
+		return EPROTO;
 	}
 
 	if (chunk->mb->pos >= chunk->mb->size) {


### PR DESCRIPTION
it is possible to receive an RTMP format 3 message after format 0,1,2 even if the
total payload is not fragmented.

```
   Type 3 chunks have no message header.  The stream ID, message length
   and timestamp delta fields are not present; chunks of this type take
   values from the preceding chunk for the same Chunk Stream ID.  When a
   single message is split into chunks, all chunks of a message except
   the first one SHOULD use this type.  Refer to Example 2
   (Section 5.3.2.2).  A stream consisting of messages of exactly the
   same size, stream ID and spacing in time SHOULD use this type for all
   chunks after a chunk of Type 2.  Refer to Example 1
   (Section 5.3.2.1).  If the delta between the first message and the
   second message is same as the timestamp of the first message, then a
   chunk of Type 3 could immediately follow the chunk of Type 0 as there
   is no need for a chunk of Type 2 to register the delta.  If a Type 3
   chunk follows a Type 0 chunk, then the timestamp delta for this Type
   3 chunk is the same as the timestamp of the Type 0 chunk.
```

this is the initial fix, need to test it a bit more.
