### PR TITLE
rtmp: add rtmp_meta() to send metadata on stream

### DIFF
--- a/include/re_rtmp.h
+++ b/include/re_rtmp.h
@@ -125,6 +125,7 @@ int rtmp_stream_create(struct rtmp_stream **strmp, struct rtmp_conn *conn,
 		       void *arg);
 int rtmp_play(struct rtmp_stream *strm, const char *name);
 int rtmp_publish(struct rtmp_stream *strm, const char *name);
+int rtmp_meta(struct rtmp_stream *strm);
 int rtmp_send_audio(struct rtmp_stream *strm, uint32_t timestamp,
 		    const uint8_t *pld, size_t len);
 int rtmp_send_video(struct rtmp_stream *strm, uint32_t timestamp,

--- a/src/rtmp/stream.c
+++ b/src/rtmp/stream.c
@@ -210,6 +210,21 @@ int rtmp_publish(struct rtmp_stream *strm, const char *name)
 }
 
 
+int rtmp_meta(struct rtmp_stream *strm)
+{
+	if (!strm)
+		return EINVAL;
+
+	return rtmp_amf_data((struct rtmp_conn *)strm->conn, strm->stream_id,
+			     "@setDataFrame",
+		     2,
+		     RTMP_AMF_TYPE_STRING, "onMetaData",
+		     RTMP_AMF_TYPE_ECMA_ARRAY, 2,
+			     RTMP_AMF_TYPE_NUMBER, "audiocodecid", 10.0,
+			     RTMP_AMF_TYPE_NUMBER, "videocodecid",  7.0);
+}
+
+
 /**
  * Send audio packet on the RTMP Stream
  *


### PR DESCRIPTION
some RTMP servers expect to receive this message.
keep the content minimal for now.
