### PR TITLE
rtmp: add function to set handlers

### DIFF
--- a/include/re_rtmp.h
+++ b/include/re_rtmp.h
@@ -81,6 +81,8 @@ int rtmp_accept(struct rtmp_conn **connp, struct tcp_sock *ts,
 		rtmp_command_h *cmdh, rtmp_close_h *closeh, void *arg);
 int rtmp_control(const struct rtmp_conn *conn,
 		 enum rtmp_packet_type type, ...);
+void rtmp_set_handlers(struct rtmp_conn *conn, rtmp_command_h *cmdh,
+		       rtmp_close_h *closeh, void *arg);
 struct tcp_conn *rtmp_conn_tcpconn(const struct rtmp_conn *conn);
 const char *rtmp_conn_stream(const struct rtmp_conn *conn);
 int  rtmp_conn_debug(struct re_printf *pf, const struct rtmp_conn *conn);

--- a/src/rtmp/conn.c
+++ b/src/rtmp/conn.c
@@ -960,6 +960,14 @@ const char *rtmp_conn_stream(const struct rtmp_conn *conn)
 }
 
 
+/**
+ * Set callback handlers for the RTMP connection
+ *
+ * @param conn   RTMP connection
+ * @param cmdh   Incoming command handler
+ * @param closeh Close handler
+ * @param arg    Handler argument
+ */
 void rtmp_set_handlers(struct rtmp_conn *conn, rtmp_command_h *cmdh,
 		       rtmp_close_h *closeh, void *arg)
 {

--- a/src/rtmp/conn.c
+++ b/src/rtmp/conn.c
@@ -960,6 +960,18 @@ const char *rtmp_conn_stream(const struct rtmp_conn *conn)
 }
 
 
+void rtmp_set_handlers(struct rtmp_conn *conn, rtmp_command_h *cmdh,
+		       rtmp_close_h *closeh, void *arg)
+{
+	if (!conn)
+		return;
+
+	conn->cmdh   = cmdh;
+	conn->closeh = closeh;
+	conn->arg    = arg;
+}
+
+
 static const char *rtmp_handshake_name(enum rtmp_handshake_state state)
 {
 	switch (state) {


### PR DESCRIPTION
adds a new function to set the RTMP connection callback handlers.

@richaas please review and merge to master