### PR TITLE
rtmp: add extended timestamp for type 3

### DIFF
--- a/src/rtmp/chunk.c
+++ b/src/rtmp/chunk.c
@@ -67,6 +67,10 @@ int rtmp_chunker(unsigned format, uint32_t chunk_id,
 		chunk_sz = min(len, max_chunk_sz);
 
 		err  = rtmp_header_encode(mb, &hdr);
+
+		if (timestamp >= 0xffffff)
+			err |= mbuf_write_u32(mb, htonl(timestamp));
+
 		err |= mbuf_write_mem(mb, payload, chunk_sz);
 		if (err)
 			goto out;

--- a/src/rtmp/dechunk.c
+++ b/src/rtmp/dechunk.c
@@ -204,6 +204,17 @@ int rtmp_dechunker_receive(struct rtmp_dechunker *rd, struct mbuf *mb)
 			chunk->hdr.timestamp += chunk->hdr.timestamp_delta;
 		}
 
+		if (chunk->hdr.timestamp >= 0x00ffffff) {
+			uint32_t ext_ts;
+
+			if (mbuf_get_left(mb) < 4)
+				return ENODATA;
+
+			ext_ts = ntohl(mbuf_read_u32(mb));
+
+			(void)ext_ts;  /* ignored */
+		}
+
 		left = mbuf_get_space(chunk->mb);
 
 		chunk_sz = min(left, rd->chunk_sz);

--- a/src/rtmp/rtmp.h
+++ b/src/rtmp/rtmp.h
@@ -5,6 +5,9 @@
  */
 
 
+#define TIMESTAMP_MAX 0x00ffffff
+
+
 enum {
 	RTMP_PROTOCOL_VERSION  = 3,
 	RTMP_DEFAULT_CHUNKSIZE = 128,


### PR DESCRIPTION
The extended timestamp should also be present for Type 3 packets.
