### PR TITLE
Fix libdir in pkgconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 libre.pc:
 	@echo 'prefix='$(PREFIX) > libre.pc
 	@echo 'exec_prefix=$${prefix}' >> libre.pc
-	@echo 'libdir=$${prefix}/lib' >> libre.pc
+	@echo 'libdir=$(LIBDIR)' >> libre.pc
 	@echo 'includedir=$${prefix}/include/re' >> libre.pc
 	@echo '' >> libre.pc
 	@echo 'Name: libre' >> libre.pc


### PR DESCRIPTION
The library directory can be specified by user in LIBDIR but it was not reflected in libre.pc. This commit fixes this.