### PR TITLE
Updating odict, websock and re.mk doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ install:
     - wget "https://github.com/alfredh/pytools/raw/master/ccheck.py"
 
 script: 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
         make EXTRA_CFLAGS=-Werror CCACHE=;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
         make EXTRA_CFLAGS="-I/usr/local/opt/openssl/include -Werror" EXTRA_LFLAGS="-L/usr/local/opt/openssl/lib" CCACHE=;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python2 ccheck.py ; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then python2 ccheck.py ; fi

--- a/include/re_odict.h
+++ b/include/re_odict.h
@@ -33,6 +33,7 @@ struct odict_entry {
 };
 
 int odict_alloc(struct odict **op, uint32_t hash_size);
+struct odict *odict_new(uint32_t hash_size);
 const struct odict_entry *odict_lookup(const struct odict *o, const char *key);
 size_t odict_count(const struct odict *o, bool nested);
 int odict_debug(struct re_printf *pf, const struct odict *o);

--- a/include/re_websock.h
+++ b/include/re_websock.h
@@ -47,9 +47,8 @@ struct websock;
 struct websock_conn;
 
 typedef void (websock_estab_h)(void *arg);
-typedef void (websock_recv_h)(const struct websock_hdr *hdr, struct mbuf *mb,
-			      void *arg);
-typedef void (websock_close_h)(int err, void *arg);
+typedef void (websock_recv_h)(struct websock_conn *conn, struct websock_hdr *hdr, struct mbuf *mb, void *arg);
+typedef void (websock_close_h)(struct websock_conn *conn, int err, void *arg);
 
 
 int websock_connect(struct websock_conn **connp, struct websock *sock,

--- a/include/re_websock.h
+++ b/include/re_websock.h
@@ -47,7 +47,8 @@ struct websock;
 struct websock_conn;
 
 typedef void (websock_estab_h)(void *arg);
-typedef void (websock_recv_h)(struct websock_conn *conn, struct websock_hdr *hdr, struct mbuf *mb, void *arg);
+typedef void (websock_recv_h)(struct websock_conn *conn,
+		struct websock_hdr *hdr, struct mbuf *mb, void *arg);
 typedef void (websock_close_h)(struct websock_conn *conn, int err, void *arg);
 
 

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -810,20 +810,19 @@ clang:
 #
 # Documentation section
 #
-DOX_DIR=../$(PROJECT)-dox
-DOX_TAR=$(PROJECT)-dox-$(VERSION)
+DOX_DIR	= ../$(PROJECT)-dox
+DOX_TAR	= $(PROJECT)-dox-$(VERSION)
+DOX_HAVE_DOT	:= $(shell [ -f /usr/bin/dot ] || [ -f /usr/local/bin/dot ] && echo "YES")
+ifeq ($(DOX_HAVE_DOT),)
+DOX_HAVE_DOT	:= NO
+endif
 
 $(DOX_DIR):
 	@mkdir $@
 
-$(DOX_DIR)/Doxyfile: mk/Doxyfile Makefile
-	@cp $< $@
-	@perl -pi -e 's/PROJECT_NUMBER\s*=.*/PROJECT_NUMBER = $(VERSION)/' \
-	$(DOX_DIR)/Doxyfile
-
 .PHONY:
-dox:	$(DOX_DIR) $(DOX_DIR)/Doxyfile
-	@doxygen $(DOX_DIR)/Doxyfile 2>&1 | grep -v DEBUG_ ; true
-	@cd .. && rm -f $(DOX_TAR).tar.gz && \
-	tar -zcf $(DOX_TAR).tar.gz $(PROJECT)-dox > /dev/null && \
-	echo "Doxygen docs in `pwd`/$(DOX_TAR).tar.gz"
+dox:	$(DOX_DIR)
+	@( cat mk/Doxyfile ; echo "PROJECT_NUMBER=$(VERSION)"; echo "HAVE_DOT=$(DOX_HAVE_DOT)" ) | doxygen -
+	@cd .. && rm -f $(PROJECT)/$(DOX_TAR).tar.gz && \
+	tar -zcf $(PROJECT)/$(DOX_TAR).tar.gz $(PROJECT)-dox > /dev/null && \
+	echo "Doxygen docs in `pwd`/$(PROJECT)/$(DOX_TAR).tar.gz"

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -812,7 +812,8 @@ clang:
 #
 DOX_DIR	= ../$(PROJECT)-dox
 DOX_TAR	= $(PROJECT)-dox-$(VERSION)
-DOX_HAVE_DOT	:= $(shell [ -f /usr/bin/dot ] || [ -f /usr/local/bin/dot ] && echo "YES")
+DOX_HAVE_DOT	:= $(shell [ -f /usr/bin/dot ] || [ -f /usr/local/bin/dot ] \
+	&& echo "YES")
 ifeq ($(DOX_HAVE_DOT),)
 DOX_HAVE_DOT	:= NO
 endif
@@ -822,7 +823,8 @@ $(DOX_DIR):
 
 .PHONY:
 dox:	$(DOX_DIR)
-	@( cat mk/Doxyfile ; echo "PROJECT_NUMBER=$(VERSION)"; echo "HAVE_DOT=$(DOX_HAVE_DOT)" ) | doxygen -
-	@cd .. && rm -f $(PROJECT)/$(DOX_TAR).tar.gz && \
-	tar -zcf $(PROJECT)/$(DOX_TAR).tar.gz $(PROJECT)-dox > /dev/null && \
-	echo "Doxygen docs in `pwd`/$(PROJECT)/$(DOX_TAR).tar.gz"
+	@( cat mk/Doxyfile ; echo "PROJECT_NUMBER=$(VERSION)"; \
+		echo "HAVE_DOT=$(DOX_HAVE_DOT)" ) | doxygen -
+	@cd .. && rm -f $(PROJECT)/$(DOX_TAR).tar.gz \
+		&& tar -zcf $(PROJECT)/$(DOX_TAR).tar.gz $(PROJECT)-dox > /dev/null \
+		&& echo "Doxygen docs in `pwd`/$(PROJECT)/$(DOX_TAR).tar.gz"

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -825,6 +825,6 @@ $(DOX_DIR):
 dox:	$(DOX_DIR)
 	@( cat mk/Doxyfile ; echo "PROJECT_NUMBER=$(VERSION)"; \
 		echo "HAVE_DOT=$(DOX_HAVE_DOT)" ) | doxygen -
-	@cd .. && rm -f $(PROJECT)/$(DOX_TAR).tar.gz \
-		&& tar -zcf $(PROJECT)/$(DOX_TAR).tar.gz $(PROJECT)-dox > /dev/null \
-		&& echo "Doxygen docs in `pwd`/$(PROJECT)/$(DOX_TAR).tar.gz"
+	@cd .. && rm -f $(PROJECT)/$(DOX_TAR).tar.gz &&\
+	tar -zcf $(PROJECT)/$(DOX_TAR).tar.gz $(PROJECT)-dox >/dev/null\
+	&& echo "Doxygen docs in `pwd`/$(PROJECT)/$(DOX_TAR).tar.gz"

--- a/src/odict/odict.c
+++ b/src/odict/odict.c
@@ -46,6 +46,11 @@ int odict_alloc(struct odict **op, uint32_t hash_size)
 	return err;
 }
 
+struct odict *odict_new(uint32_t hash_size) {
+	struct odict *that;
+	odict_alloc(&that, hash_size);
+	return that;
+}
 
 const struct odict_entry *odict_lookup(const struct odict *o, const char *key)
 {

--- a/src/websock/websock.c
+++ b/src/websock/websock.c
@@ -66,7 +66,8 @@ static const char magic[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 static void timeout_handler(void *arg);
 
 
-static void dummy_recv_handler(struct websock_conn *conn, struct websock_hdr *hdr, struct mbuf *mb, void *arg)
+static void dummy_recv_handler(struct websock_conn *conn,
+		struct websock_hdr *hdr, struct mbuf *mb, void *arg)
 {
 	(void)conn;
 	(void)hdr;
@@ -75,7 +76,8 @@ static void dummy_recv_handler(struct websock_conn *conn, struct websock_hdr *hd
 }
 
 
-static void internal_close_handler(struct websock_conn *conn, int err, void *arg)
+static void internal_close_handler(struct websock_conn *conn, int err,
+		void *arg)
 {
 	(void)err;
 	(void)arg;

--- a/src/websock/websock.c
+++ b/src/websock/websock.c
@@ -66,19 +66,19 @@ static const char magic[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 static void timeout_handler(void *arg);
 
 
-static void dummy_recv_handler(const struct websock_hdr *hdr, struct mbuf *mb,
-			       void *arg)
+static void dummy_recv_handler(struct websock_conn *conn, struct websock_hdr *hdr, struct mbuf *mb, void *arg)
 {
+	(void)conn;
 	(void)hdr;
 	(void)mb;
 	(void)arg;
 }
 
 
-static void internal_close_handler(int err, void *arg)
+static void internal_close_handler(struct websock_conn *conn, int err, void *arg)
 {
-	struct websock_conn *conn = arg;
 	(void)err;
+	(void)arg;
 
 	mem_deref(conn);
 }
@@ -134,7 +134,7 @@ static void conn_close(struct websock_conn *conn, int err)
 	conn->tc = mem_deref(conn->tc);
 	conn->state = CLOSED;
 
-	conn->closeh(err, conn->arg);
+	conn->closeh(conn, err, conn->arg);
 }
 
 
@@ -306,7 +306,7 @@ static void recv_handler(struct mbuf *mb, void *arg)
 		case WEBSOCK_TEXT:
 		case WEBSOCK_BIN:
 			mem_ref(conn);
-			conn->recvh(&hdr, mb, conn->arg);
+			conn->recvh(conn, &hdr, mb, conn->arg);
 
 			if (mem_nrefs(conn) == 1) {
 


### PR DESCRIPTION
This PR is adding a function `odict_new`, to allow to create an object in one line of code.

This is also adding `struct websock_conn *` to the arguments of `websock_recv_h` and `websock_close_h`.

In the makefile re.mk I've updated doxygen, to work without perl and graphwiz-dot. I didn't call `doxygen -u mk/Doxyfile` because this seems to be a huge change... What do you think? 

Updating .travis.yml: Doesn't bash just read = instead of == ?

About the formatting issues: Don't you want to rethink these expects? For example,
a line 120 bytes, with a line count of at least max 2^16 == 65535 lines * 121 = 7929735 bytes ~ 8 MB,
or a line 96 bytes, with a line count of at least max 2^16 lines * 6356895 ~ 6 MB?

Actually I'm warming up with using git and github... Is this PR okay, or should I split those changes somehow?