### PR TITLE
main: include all openssl cleanup recommendations

### DIFF
--- a/src/main/openssl.c
+++ b/src/main/openssl.c
@@ -158,8 +158,19 @@ int openssl_init(void)
 
 void openssl_close(void)
 {
+	// https://wiki.openssl.org/index.php/Library_Initialization#Cleanup
+	FIPS_mode_set(0);
+	EVP_PBE_cleanup();
+	EVP_cleanup();
+	CRYPTO_cleanup_all_ex_data();
 	ERR_free_strings();
-#if defined (HAVE_PTHREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+	SSL_COMP_free_compression_methods();
+#if defined (HAVE_PTHREAD)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+	ERR_remove_thread_state(NULL);
 	lockv = mem_deref(lockv);
+#elif (OPENSSL_VERSION_NUMBER < 0x10000000L)
+	ERR_remove_state(0);
+#endif
 #endif
 }


### PR DESCRIPTION
Fixes leaks detected by `valgrind` from `libre_init` even after `libre_close` is called.
The original clean-up code was missing much of the recommended calls listed in https://wiki.openssl.org/index.php/Library_Initialization#Cleanup