### PR TITLE
Update MSVS project (Remove uri_cmp)

### DIFF
--- a/mk/win32/re.vcxproj
+++ b/mk/win32/re.vcxproj
@@ -246,7 +246,6 @@
     <ClCompile Include="..\..\src\turn\turnc.c" />
     <ClCompile Include="..\..\src\udp\mcast.c" />
     <ClCompile Include="..\..\src\udp\udp.c" />
-    <ClCompile Include="..\..\src\uri\ucmp.c" />
     <ClCompile Include="..\..\src\uri\uri.c" />
     <ClCompile Include="..\..\src\uri\uric.c" />
   </ItemGroup>

--- a/mk/win32/re.vcxproj.filters
+++ b/mk/win32/re.vcxproj.filters
@@ -353,9 +353,6 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\uri\ucmp.c">
-      <Filter>src\uri</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\uri\uri.c">
       <Filter>src\uri</Filter>
     </ClCompile>


### PR DESCRIPTION
Hello!
Recently, in commit 9ec2b170188bceac80c00bfd95ba78b99ce960b5 file `uri/ucmp.c` was removed. This PR removes it from build list in Visual Studio