### PR TITLE
Make able to set output handler instead of stdout

### DIFF
--- a/include/re_fmt.h
+++ b/include/re_fmt.h
@@ -92,6 +92,8 @@ int re_printf(const char *fmt, ...);
 int re_snprintf(char *str, size_t size, const char *fmt, ...);
 int re_sdprintf(char **strp, const char *fmt, ...);
 
+int re_set_output_handler(struct re_printf *log_handler);
+
 
 /* Regular expressions */
 int re_regex(const char *ptr, size_t len, const char *expr, ...);


### PR DESCRIPTION
Hello!
There are some places where re_printf is used. Unfortunatelly, these messages can not be retarget to specific log handler. We are using re/rem/baresip as a library, so it will be awesome if application could control output.
Also, we are using patch https://github.com/creytiv/re/commit/49834b7afd0fe31660108271ef7657a34caa6a6d for windows and messages `$$$ NOTE - USING EXPERIMENTAL RE_MAIN $$$` and `fd_set updated` are spaming to console

This patch will not break any exist code, but will add possibility to set some specific log handler.

In this implementation method `re_vhprintf` can not be used instead of `re_vsnprintf` because in case of formatted string it will call log handler multiple times. For example message `re_printf("Test float = %f\n", 4.5f);` will convert into multiple function calls:
```
Test float = %f
4.5
<new line>
````

Usage example:
```c
static int my_re_log_handler(const char *p, size_t size, void *arg)
{
    // Some example logging
    some_external_logging(p, size, arg);
    return 0;
}

...
struct re_printf reLogHandler;
reLogHandler.vph = my_re_log_handler;
reLogHandler.arg = NULL;
re_set_output_handler(&reLogHandler);
```