### PR TITLE
tls: don't close connection on SSL_ERROR_ZERO_RETURN

### DIFF
--- a/src/tls/openssl/tls_tcp.c
+++ b/src/tls/openssl/tls_tcp.c
@@ -306,12 +306,9 @@ static bool recv_handler(int *err, struct mbuf *mb, bool *estab, void *arg)
 
 			switch (ssl_err) {
 
+			case SSL_ERROR_ZERO_RETURN:
 			case SSL_ERROR_WANT_READ:
 				break;
-
-			case SSL_ERROR_ZERO_RETURN:
-				*err = ECONNRESET;
-				return true;
 
 			default:
 				*err = EPROTO;


### PR DESCRIPTION
If a TLS closure alert is observed before all received data is handed to the application, the TCP connection is closed and the data is lost. In the proposed fix we ignore the SSL_ERROR_ZERO_RETURN error, and leave the connection open until closed at the TCP level.