### PR TITLE
Honour interface preference

### DIFF
--- a/include/re_dns.h
+++ b/include/re_dns.h
@@ -200,6 +200,7 @@ struct dnsc_conf {
 	uint32_t tcp_hash_size;
 	uint32_t conn_timeout;  /* in [ms] */
 	uint32_t idle_timeout;  /* in [ms] */
+	struct sa *laddr;
 };
 
 int  dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
@@ -216,6 +217,7 @@ int  dnsc_notify(struct dns_query **qp, struct dnsc *dnsc, const char *name,
 		 uint16_t type, uint16_t dnsclass, const struct dnsrr *ans_rr,
 		 int proto, const struct sa *srvv, const uint32_t *srvc,
 		 dns_query_h *qh, void *arg);
+void dnsc_copy_default_config(struct dnsc_conf *conf);
 
 
 /* DNS System functions */

--- a/include/re_tcp.h
+++ b/include/re_tcp.h
@@ -64,6 +64,8 @@ int  tcp_conn_alloc(struct tcp_conn **tcp, const struct sa *peer,
 		    void *arg);
 int  tcp_conn_bind(struct tcp_conn *tc, const struct sa *local);
 int  tcp_conn_connect(struct tcp_conn *tc, const struct sa *peer);
+int  tcp_conn_connect_hint(struct tcp_conn *tc, const struct sa *peer,
+			const struct sa *send_hint);
 int  tcp_send(struct tcp_conn *tc, struct mbuf *mb);
 int  tcp_set_send(struct tcp_conn *tc, tcp_send_h *sendh);
 void tcp_set_handlers(struct tcp_conn *tc, tcp_estab_h *eh, tcp_recv_h *rh,
@@ -79,8 +81,11 @@ size_t tcp_conn_txqsz(const struct tcp_conn *tc);
 /* High-level API */
 int  tcp_listen(struct tcp_sock **tsp, const struct sa *local,
 		tcp_conn_h *ch, void *arg);
-int  tcp_connect(struct tcp_conn **tcp, const struct sa *peer,
-		 tcp_estab_h *eh, tcp_recv_h *rh, tcp_close_h *ch, void *arg);
+int  tcp_connect_hint(struct tcp_conn **tcp, const struct sa *peer,
+		 const struct sa *local, tcp_estab_h *eh, tcp_recv_h *rh,
+		 tcp_close_h *ch, void *arg);
+int tcp_connect(struct tcp_conn **tcp, const struct sa *peer,
+		tcp_estab_h *eh, tcp_recv_h *rh, tcp_close_h *ch, void *arg);
 int  tcp_local_get(const struct tcp_sock *ts, struct sa *local);
 
 

--- a/include/re_udp.h
+++ b/include/re_udp.h
@@ -23,6 +23,8 @@ typedef void (udp_error_h)(int err, void *arg);
 int  udp_listen(struct udp_sock **usp, const struct sa *local,
 		udp_recv_h *rh, void *arg);
 int  udp_connect(struct udp_sock *us, const struct sa *peer);
+int  udp_connect_hint(struct udp_sock *us, const struct sa *peer,
+		const struct sa *send_hint);
 int  udp_send(struct udp_sock *us, const struct sa *dst, struct mbuf *mb);
 int  udp_send_anon(const struct sa *dst, struct mbuf *mb);
 int  udp_local_get(const struct udp_sock *us, struct sa *local);

--- a/src/dns/client.c
+++ b/src/dns/client.c
@@ -16,6 +16,7 @@
 #include <re_tcp.h>
 #include <re_sys.h>
 #include <re_dns.h>
+#include <re_net.h>
 
 
 #define DEBUG_MODULE "dnsc"
@@ -91,6 +92,7 @@ static const struct dnsc_conf default_conf = {
 	TCP_HASH_SIZE,
 	CONN_TIMEOUT,
 	IDLE_TIMEOUT,
+	NULL,
 };
 
 
@@ -856,7 +858,7 @@ int dnsc_alloc(struct dnsc **dcpp, const struct dnsc_conf *conf,
 	if (err)
 		goto out;
 
-	err = udp_listen(&dnsc->us, NULL, udp_recv_handler, dnsc);
+	err = udp_listen(&dnsc->us, dnsc->conf.laddr, udp_recv_handler, dnsc);
 	if (err)
 		goto out;
 
@@ -902,4 +904,15 @@ int dnsc_srv_set(struct dnsc *dnsc, const struct sa *srvv, uint32_t srvc)
 	}
 
 	return 0;
+}
+
+/**
+ * Copy the default config into the provided container
+ *
+ * @param conf The container into which the default config
+ *             will get copied.
+ */
+void dnsc_copy_default_config(struct dnsc_conf *conf)
+{
+	memcpy(conf, &default_conf, sizeof(*conf));
 }


### PR DESCRIPTION
An interface or address preference can be set by clients.  However, this
is not always honoured - instead leaving it to the OS to choose the
interface on which to send the packets.  This is usually The Right Thing
to do as the OS is in the best place to choose the interface that will
most likely get the packet to the destination via the ip address / route
metric mechanisms.

However, in certain use cases where a clear preference has been
identified by the client, libre should be doing its best to use that as
the outgoing interface.  This can be achieved in two ways (that I know
of).

1) Set the socket option SO_BINDTODEVICE which requires net admin
privileges
or
2) Call bind() on the socket with the desired address which will set the
src address in the packets correctly, and it is then up to the OS for
which physical interface the packets are sent on, but with the src
address set, it is much easier to configure the OS to always send
those packets to a particular device.

I have avoided causing breaking changes to the public API, so I have added `*_hint` functions where applicable.  I am absolutely willing to modify this where necessary - the behaviour doesn't actually change if the `struct sa *` hint address passed in is NULL.

Mostly this is a PR to get a feeling for the appetite for this change.  It's kind of a special use case, so I don't know if it's actually something you are interested in maintaining. 
