### PR TITLE
fixing crash when not using pthreads

### DIFF
--- a/include/re_dbg.h
+++ b/include/re_dbg.h
@@ -177,7 +177,7 @@ enum dbg_flags {
  */
 typedef void (dbg_print_h)(int level, const char *p, size_t len, void *arg);
 
-void dbg_init(int level, enum dbg_flags flags);
+int  dbg_init(int level, enum dbg_flags flags);
 void dbg_close(void);
 int  dbg_logfile_set(const char *name);
 void dbg_handler_set(dbg_print_h *ph, void *arg);

--- a/src/dbg/dbg.c
+++ b/src/dbg/dbg.c
@@ -59,15 +59,20 @@ static inline void dbg_unlock(void)
  *
  * @param level Debug level
  * @param flags Debug flags
+ * 
+ * @return 0 if success, otherwise errorcode
  */
-void dbg_init(int level, enum dbg_flags flags)
+int dbg_init(int level, enum dbg_flags flags)
 {
 	if (!dbg.mutex) {
-		lock_alloc(&dbg.mutex);
+		int err = lock_alloc(&dbg.mutex);
+		if (err)
+			return err;
 	}
 	dbg.tick  = tmr_jiffies();
 	dbg.level = level;
 	dbg.flags = flags;
+	return 0;
 }
 
 

--- a/src/dbg/dbg.c
+++ b/src/dbg/dbg.c
@@ -59,7 +59,7 @@ static inline void dbg_unlock(void)
  *
  * @param level Debug level
  * @param flags Debug flags
- * 
+ *
  * @return 0 if success, otherwise errorcode
  */
 int dbg_init(int level, enum dbg_flags flags)


### PR DESCRIPTION
If you aren't using pthreads, this file will cause baresip to crash. I have fixed this by replacing the pthreads mutex with the one used in re_lock.