### PR TITLE
do not fail authorization if it has succeed before

### DIFF
--- a/src/sip/auth.c
+++ b/src/sip/auth.c
@@ -161,7 +161,9 @@ static bool auth_handler(const struct sip_hdr *hdr, const struct sip_msg *msg,
 			goto out;
 	}
 	else {
-		if (!pl_isset(&ch.stale) || pl_strcasecmp(&ch.stale, "true")) {
+		/* error if first auth attempt fails */
+		if ((!pl_isset(&ch.stale) ||
+		     pl_strcasecmp(&ch.stale, "true")) && (realm->nc == 2)) {
 			err = EAUTH;
 			goto out;
 		}


### PR DESCRIPTION
hack needed for servers that do not include stale=true in response