### PR TITLE
Set SDK path (SYSROOT) using xcrun (fix building on macOS 10.14)

### DIFF
--- a/mk/re.mk
+++ b/mk/re.mk
@@ -271,6 +271,7 @@ endif
 	AFLAGS		:= cru
 	LIB_SUFFIX	:= .dylib
 	HAVE_KQUEUE	:= 1
+	SYSROOT		:= $(shell xcrun --show-sdk-path)/usr
 endif
 ifeq ($(OS),netbsd)
 	CFLAGS		+= -fPIC -DNETBSD


### PR DESCRIPTION
See #191 for details.