### PR TITLE
Rfc3581 received rport parsing

### DIFF
--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -144,6 +144,7 @@ struct sip_via {
 	struct pl params;
 	struct pl branch;
 	struct pl val;
+	struct sa received;
 	enum sip_transp tp;
 };
 

--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -16,3 +16,5 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 		    const char *params, const char *fmt, ...);
 
 const struct sa *sipreg_laddr(const struct sipreg *reg);
+
+const struct sa *get_via_received(const struct sip_msg *msg);

--- a/src/sip/via.c
+++ b/src/sip/via.c
@@ -37,7 +37,8 @@ static int decode_hostport(const struct pl *hostport, struct pl *host,
  */
 int sip_via_decode(struct sip_via *via, const struct pl *pl)
 {
-	struct pl transp, host, port;
+	struct pl transp, host, port, received, rport;
+	uint32_t rp;
 	int err;
 
 	if (!via || !pl)
@@ -72,6 +73,13 @@ int sip_via_decode(struct sip_via *via, const struct pl *pl)
 		sa_set_port(&via->addr, pl_u32(&port));
 
 	via->val = *pl;
+
+	if ((0 == msg_param_decode(&via->params, "received", &received)) &&
+		(0 == msg_param_decode(&via->params, "rport", &rport)) &&
+		(rp = pl_u32(&rport))) {
+
+		sa_set(&via->received, &received, rp);
+	}
 
 	return msg_param_decode(&via->params, "branch", &via->branch);
 }


### PR DESCRIPTION
Parse the received and rport parameter in the registration answer defined in RFC3581 from the server to use it in a later commit for the contact header.