### PR TITLE
sipsess: add handler for contact

### DIFF
--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -19,6 +19,7 @@ typedef void (sipsess_info_h)(struct sip *sip, const struct sip_msg *msg,
 typedef void (sipsess_refer_h)(struct sip *sip, const struct sip_msg *msg,
 			       void *arg);
 typedef void (sipsess_close_h)(int err, const struct sip_msg *msg, void *arg);
+typedef struct sip_contact *(sipsess_contact_h)(void *arg);
 
 
 int  sipsess_listen(struct sipsess_sock **sockp, struct sip *sip,
@@ -32,6 +33,7 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		     sip_auth_h *authh, void *aarg, bool aref,
 		     sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		     sipsess_progr_h *progrh, sipsess_estab_h *estabh,
+ 		     sipsess_contact_h *contacth,
 		     sipsess_info_h *infoh, sipsess_refer_h *referh,
 		     sipsess_close_h *closeh, void *arg, const char *fmt, ...);
 
@@ -41,9 +43,9 @@ int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    struct mbuf *desc,
 		    sip_auth_h *authh, void *aarg, bool aref,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
-		    sipsess_estab_h *estabh, sipsess_info_h *infoh,
-		    sipsess_refer_h *referh, sipsess_close_h *closeh,
-		    void *arg, const char *fmt, ...);
+		    sipsess_estab_h *estabh, sipsess_contact_h *contacth,
+		    sipsess_info_h *infoh, sipsess_refer_h *referh,
+		    sipsess_close_h *closeh, void *arg, const char *fmt, ...);
 
 int  sipsess_progress(struct sipsess *sess, uint16_t scode,
 		      const char *reason, struct mbuf *desc,

--- a/src/sipsess/ack.c
+++ b/src/sipsess/ack.c
@@ -77,8 +77,8 @@ static void resp_handler(int err, const struct sip_msg *msg, void *arg)
 }
 
 
-int sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
-		uint32_t cseq, struct sip_auth *auth,
+int sipsess_ack(struct sipsess *sess, struct sipsess_sock *sock,
+		struct sip_dialog *dlg,	uint32_t cseq, struct sip_auth *auth,
 		const char *ctype, struct mbuf *desc)
 {
 	struct sipsess_ack *ack;
@@ -96,17 +96,21 @@ int sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
 	ack->cseq = cseq;
 
 	err = sip_drequestf(&ack->req, sock->sip, false, "ACK", dlg, cseq,
-			    auth, send_handler, resp_handler, ack,
-			    "%s%s%s"
-			    "Content-Length: %zu\r\n"
-			    "\r\n"
-			    "%b",
-			    desc ? "Content-Type: " : "",
-			    desc ? ctype : "",
-			    desc ? "\r\n" : "",
-			    desc ? mbuf_get_left(desc) : (size_t)0,
-			    desc ? mbuf_buf(desc) : NULL,
-			    desc ? mbuf_get_left(desc) : (size_t)0);
+				auth, send_handler, resp_handler, ack,
+				"%H"
+				"%s%s%s"
+				"Content-Length: %zu\r\n"
+				"\r\n"
+				"%b",
+				sip_contact_print, sess->contacth(sess->arg),
+				desc ? "Content-Type: " : "",
+				desc ? ctype : "",
+				desc ? "\r\n" : "",
+				desc ? mbuf_get_left(desc) : (size_t)0,
+				desc ? mbuf_buf(desc) : NULL,
+				desc ? mbuf_get_left(desc) : (size_t)0);
+
+
 	if (err)
 		goto out;
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -29,9 +29,14 @@ static int send_handler(enum sip_transp tp, const struct sa *src,
 	struct sipsess *sess = arg;
 	(void)dst;
 
-	sip_contact_set(&contact, sess->cuser, src, tp);
+	if (!sess->contacth(sess->arg)) {
+		sip_contact_set(&contact, sess->cuser, src, tp);
 
-	return mbuf_printf(mb, "%H", sip_contact_print, &contact);
+		return mbuf_printf(mb, "%H", sip_contact_print, &contact);
+	}
+
+	return mbuf_printf(mb, "%H", sip_contact_print,
+			   sess->contacth(sess->arg));
 }
 
 
@@ -62,7 +67,7 @@ static void invite_resp_handler(int err, const struct sip_msg *msg, void *arg)
 			err = sess->offerh(&desc, msg, sess->arg);
 		}
 
-		err |= sipsess_ack(sess->sock, sess->dlg, msg->cseq.num,
+		err |= sipsess_ack(sess, sess->sock, sess->dlg, msg->cseq.num,
 				   sess->auth, sess->ctype, desc);
 
 		sess->established = true;
@@ -186,6 +191,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sip_auth_h *authh, void *aarg, bool aref,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_progr_h *progrh, sipsess_estab_h *estabh,
+		    sipsess_contact_h *contacth,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
 		    sipsess_close_h *closeh, void *arg, const char *fmt, ...)
 {
@@ -196,8 +202,8 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		return EINVAL;
 
 	err = sipsess_alloc(&sess, sock, cuser, ctype, desc, authh, aarg, aref,
-			    offerh, answerh, progrh, estabh, infoh, referh,
-			    closeh, arg);
+			    offerh, answerh, progrh, estabh, contacth, infoh,
+			    referh, closeh, arg);
 	if (err)
 		return err;
 

--- a/src/sipsess/modify.c
+++ b/src/sipsess/modify.c
@@ -50,7 +50,7 @@ static void reinvite_resp_handler(int err, const struct sip_msg *msg,
 			(void)sess->offerh(&desc, msg, sess->arg);
 		}
 
-		(void)sipsess_ack(sess->sock, sess->dlg, msg->cseq.num,
+		(void)sipsess_ack(sess, sess->sock, sess->dlg, msg->cseq.num,
 				  sess->auth, sess->ctype, desc);
 		mem_deref(desc);
 	}
@@ -113,9 +113,14 @@ static int send_handler(enum sip_transp tp, const struct sa *src,
 	struct sipsess *sess = arg;
 	(void)dst;
 
-	sip_contact_set(&contact, sess->cuser, src, tp);
+	if (!sess->contacth(sess->arg)) {
+		sip_contact_set(&contact, sess->cuser, src, tp);
 
-	return mbuf_printf(mb, "%H", sip_contact_print, &contact);
+		return mbuf_printf(mb, "%H", sip_contact_print, &contact);
+	}
+
+	return mbuf_printf(mb, "%H", sip_contact_print,
+			   sess->contacth(sess->arg));
 }
 
 

--- a/src/sipsess/reply.c
+++ b/src/sipsess/reply.c
@@ -82,7 +82,6 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 		      const char *fmt, va_list *ap)
 {
 	struct sipsess_reply *reply;
-	struct sip_contact contact;
 	int err = ENOMEM;
 
 	reply = mem_zalloc(sizeof(*reply), destructor);
@@ -94,8 +93,6 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 	reply->msg  = mem_ref((void *)msg);
 	reply->sess = sess;
 
-	sip_contact_set(&contact, sess->cuser, &msg->dst, msg->tp);
-
 	err = sip_treplyf(&sess->st, &reply->mb, sess->sip,
 			  msg, true, scode, reason,
 			  "%H"
@@ -104,7 +101,7 @@ int sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,
 			  "Content-Length: %zu\r\n"
 			  "\r\n"
 			  "%b",
-			  sip_contact_print, &contact,
+			  sip_contact_print, sess->contacth(sess->arg),
 			  fmt, ap,
 			  desc ? "Content-Type: " : "",
 			  desc ? sess->ctype : "",

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -52,6 +52,14 @@ static void internal_establish_handler(const struct sip_msg *msg, void *arg)
 }
 
 
+static struct sip_contact *internal_contact_handler(void *arg)
+{
+	(void)arg;
+
+	return NULL;
+}
+
+
 static void internal_close_handler(int err, const struct sip_msg *msg,
 				   void *arg)
 {
@@ -159,6 +167,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		  sip_auth_h *authh, void *aarg, bool aref,
 		  sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		  sipsess_progr_h *progrh, sipsess_estab_h *estabh,
+		  sipsess_contact_h *contacth,
 		  sipsess_info_h *infoh, sipsess_refer_h *referh,
 		  sipsess_close_h *closeh, void *arg)
 {
@@ -188,6 +197,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 	sess->answerh = answerh ? answerh : internal_answer_handler;
 	sess->progrh  = progrh  ? progrh  : internal_progress_handler;
 	sess->estabh  = estabh  ? estabh  : internal_establish_handler;
+	sess->contacth = contacth ? contacth : internal_contact_handler;
 	sess->infoh   = infoh;
 	sess->referh  = referh;
 	sess->closeh  = closeh  ? closeh  : internal_close_handler;

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -30,6 +30,7 @@ struct sipsess {
 	sipsess_info_h *infoh;
 	sipsess_refer_h *referh;
 	sipsess_close_h *closeh;
+	sipsess_contact_h *contacth;
 	void *arg;
 	bool owner;
 	bool sent_offer;
@@ -69,12 +70,13 @@ int  sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		   sip_auth_h *authh, void *aarg, bool aref,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_progr_h *progrh, sipsess_estab_h *estabh,
+		   sipsess_contact_h *contacth,
 		   sipsess_info_h *infoh, sipsess_refer_h *referh,
 		   sipsess_close_h *closeh, void *arg);
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg);
-int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,
-		uint32_t cseq, struct sip_auth *auth,
+int sipsess_ack(struct sipsess *sess, struct sipsess_sock *sock,
+		struct sip_dialog *dlg,	uint32_t cseq, struct sip_auth *auth,
 		const char *ctype, struct mbuf *desc);
 int  sipsess_ack_again(struct sipsess_sock *sock, const struct sip_msg *msg);
 int  sipsess_reply_2xx(struct sipsess *sess, const struct sip_msg *msg,


### PR DESCRIPTION
Adding handler sipsess_contact_h that returns a
struct sip_contact used by sip_contact_print().
The contact handler is used contact information
saved in an application using re.