### PR TITLE
WIP: Add support for in-call NOTIFY's

### DIFF
--- a/include/re_dbg.h
+++ b/include/re_dbg.h
@@ -4,6 +4,8 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -18,7 +18,7 @@ typedef void (sipsess_info_h)(struct sip *sip, const struct sip_msg *msg,
 			      void *arg);
 typedef void (sipsess_refer_h)(struct sip *sip, const struct sip_msg *msg,
 			       void *arg);
-typedef void (sipsess_notify_h)(struct sip *sip, const struct sip_msg *msg,
+typedef bool (sipsess_notify_h)(struct sip *sip, const struct sip_msg *msg,
 			      void *arg);
 typedef void (sipsess_close_h)(int err, const struct sip_msg *msg, void *arg);
 

--- a/include/re_sipsess.h
+++ b/include/re_sipsess.h
@@ -18,6 +18,8 @@ typedef void (sipsess_info_h)(struct sip *sip, const struct sip_msg *msg,
 			      void *arg);
 typedef void (sipsess_refer_h)(struct sip *sip, const struct sip_msg *msg,
 			       void *arg);
+typedef void (sipsess_notify_h)(struct sip *sip, const struct sip_msg *msg,
+			      void *arg);
 typedef void (sipsess_close_h)(int err, const struct sip_msg *msg, void *arg);
 
 
@@ -33,7 +35,8 @@ int  sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		     sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		     sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		     sipsess_info_h *infoh, sipsess_refer_h *referh,
-		     sipsess_close_h *closeh, void *arg, const char *fmt, ...);
+		     sipsess_notify_h *notifyh, sipsess_close_h *closeh,
+		     void *arg, const char *fmt, ...);
 
 int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    const struct sip_msg *msg, uint16_t scode,
@@ -42,7 +45,8 @@ int  sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sip_auth_h *authh, void *aarg, bool aref,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_estab_h *estabh, sipsess_info_h *infoh,
-		    sipsess_refer_h *referh, sipsess_close_h *closeh,
+		    sipsess_refer_h *referh, sipsess_notify_h *notifyh,
+		    sipsess_close_h *closeh,
 		    void *arg, const char *fmt, ...);
 
 int  sipsess_progress(struct sipsess *sess, uint16_t scode,

--- a/src/sipsess/accept.c
+++ b/src/sipsess/accept.c
@@ -66,7 +66,8 @@ int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 		   sip_auth_h *authh, void *aarg, bool aref,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_estab_h *estabh, sipsess_info_h *infoh,
-		   sipsess_refer_h *referh, sipsess_close_h *closeh,
+		   sipsess_refer_h *referh, sipsess_notify_h *notifyh,
+		   sipsess_close_h *closeh,
 		   void *arg, const char *fmt, ...)
 {
 	struct sipsess *sess;
@@ -79,7 +80,7 @@ int sipsess_accept(struct sipsess **sessp, struct sipsess_sock *sock,
 
 	err = sipsess_alloc(&sess, sock, cuser, ctype, NULL, authh, aarg, aref,
 			    offerh, answerh, NULL, estabh, infoh, referh,
-			    closeh, arg);
+			    notifyh, closeh, arg);
 	if (err)
 		return err;
 

--- a/src/sipsess/connect.c
+++ b/src/sipsess/connect.c
@@ -187,7 +187,8 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 		    sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		    sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		    sipsess_info_h *infoh, sipsess_refer_h *referh,
-		    sipsess_close_h *closeh, void *arg, const char *fmt, ...)
+		    sipsess_notify_h *notifyh, sipsess_close_h *closeh,
+		    void *arg, const char *fmt, ...)
 {
 	struct sipsess *sess;
 	int err;
@@ -197,7 +198,7 @@ int sipsess_connect(struct sipsess **sessp, struct sipsess_sock *sock,
 
 	err = sipsess_alloc(&sess, sock, cuser, ctype, desc, authh, aarg, aref,
 			    offerh, answerh, progrh, estabh, infoh, referh,
-			    closeh, arg);
+			    notifyh, closeh, arg);
 	if (err)
 		return err;
 

--- a/src/sipsess/sess.c
+++ b/src/sipsess/sess.c
@@ -160,7 +160,8 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		  sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		  sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		  sipsess_info_h *infoh, sipsess_refer_h *referh,
-		  sipsess_close_h *closeh, void *arg)
+		  sipsess_notify_h *notifyh, sipsess_close_h *closeh,
+		  void *arg)
 {
 	struct sipsess *sess;
 	int err;
@@ -190,6 +191,7 @@ int sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 	sess->estabh  = estabh  ? estabh  : internal_establish_handler;
 	sess->infoh   = infoh;
 	sess->referh  = referh;
+	sess->notifyh = notifyh;
 	sess->closeh  = closeh  ? closeh  : internal_close_handler;
 	sess->arg     = arg;
 

--- a/src/sipsess/sipsess.h
+++ b/src/sipsess/sipsess.h
@@ -29,6 +29,7 @@ struct sipsess {
 	sipsess_estab_h *estabh;
 	sipsess_info_h *infoh;
 	sipsess_refer_h *referh;
+	sipsess_notify_h *notifyh;
 	sipsess_close_h *closeh;
 	void *arg;
 	bool owner;
@@ -70,7 +71,8 @@ int  sipsess_alloc(struct sipsess **sessp, struct sipsess_sock *sock,
 		   sipsess_offer_h *offerh, sipsess_answer_h *answerh,
 		   sipsess_progr_h *progrh, sipsess_estab_h *estabh,
 		   sipsess_info_h *infoh, sipsess_refer_h *referh,
-		   sipsess_close_h *closeh, void *arg);
+		   sipsess_notify_h *notifyh, sipsess_close_h *closeh,
+		   void *arg);
 void sipsess_terminate(struct sipsess *sess, int err,
 		       const struct sip_msg *msg);
 int  sipsess_ack(struct sipsess_sock *sock, struct sip_dialog *dlg,


### PR DESCRIPTION
Tried to get some feedback on the mailinglist, but got no response. Trying here instead.
If the PR is acceptable as-is, please let me know, I'll cook up a better PR message.


I'm in the process of trying to support some PBX extensions to allow [remote 
control of the UA](https://github.com/alfredh/baresip/issues/758) by in-call NOTIFY's. The application to be controlled 
(baresip) is the one using re.

Unfortunately I could not find any documentation on architecture and/or call-
flows, and as a newcomer to re's code, I'm just guessing on where to add the 
needed functionality.

I would need to receive NOTIFY's that are part of the INVITE dialog, not a 
separate SUBSCRIBE dialog nor out-of-dialog. Judging by the function names I 
guessed I would need to intercept is somewhere in sipsess, just like in-dialog 
INFO messages. So I came up with the first patch in this PR.

Then I found out that baresip is also supporting REFER. Which, by the 
standard, is also using in-dialog NOTIFY's but these seem to be caught from 
within sipevent. Sipevent, by first glance, doesn't seem to have a relation to 
the sipsess of the current call and messaged are somehow coupled later on. 
Other uses of sipevent seem to suggest it is meant to be used for SUBSCRIBE 
dialogs, not INVITE based.

But due to the handling in sipevent instead of sipsess of the REFER's NOTIFY's 
I had to come up with the 2nd patch to let this still work. This is what gave rise to 
doubt about the chosen direction and about the architecture of re in general.

Note that my code is only interested in NOTIFY's which are in-dialog to the 
INVITE dialog. Out-of-dialog or NOTIFY's belonging to another call/dialog are 
not of interest and would preferably not even reach the code.

Are there separate code paths for in- and out-of-dialog messages? Or is it one 
big pile of messages and is application code supposed to find out what belongs 
where?

What would be the right place to intercept only(!) in-dialog messages 
belonging to a dialog started by an INVITE? And with "right" I mean such that 
it would be acceptable upstream, as the code is intended to be upstreamed when 
finished.
