### PR TITLE
Automatic cleanup after building debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,7 @@ clean:
 	rm -f build-stamp configure-stamp
 
 	# Add here commands to clean up after the build process.
-	$(MAKE) clean
+	$(MAKE) LIB_SUFFIX=.so.0 clean
 
 	dh_clean 
 

--- a/mk/re.mk
+++ b/mk/re.mk
@@ -736,14 +736,8 @@ git_snapshot:
 # Debian
 .PHONY: deb
 deb:
-	dpkg-buildpackage -rfakeroot
+	dpkg-buildpackage -rfakeroot --post-clean
 
-.PHONY: debclean
-debclean:
-	@rm -rf build-stamp configure-stamp debian/files debian/$(PROJECT) \
-		debian/lib$(PROJECT) debian/lib$(PROJECT)-dev debian/tmp \
-		debian/.debhelper debian/*.debhelper debian/*.debhelper.log \
-		debian/*.substvars
 
 # RPM
 RPM := $(shell [ -d /usr/src/rpm ] 2>/dev/null && echo "rpm")


### PR DESCRIPTION
This patch also makes the debclean target redundant.