### PR TITLE
JSON formatted response with sdp info initiated

### DIFF
--- a/include/re_sdp.h
+++ b/include/re_sdp.h
@@ -29,6 +29,7 @@ enum sdp_bandwidth {
 	SDP_BANDWIDTH_MAX,
 };
 
+struct odict;
 
 struct sdp_format;
 
@@ -66,20 +67,23 @@ void sdp_session_set_laddr(struct sdp_session *sess, const struct sa *laddr);
 void sdp_session_set_lbandwidth(struct sdp_session *sess,
 				enum sdp_bandwidth type, int32_t bw);
 int  sdp_session_set_lattr(struct sdp_session *sess, bool replace,
-			   const char *name, const char *value, ...);
+				const char *name, const char *value, ...);
 void sdp_session_del_lattr(struct sdp_session *sess, const char *name);
 int32_t sdp_session_lbandwidth(const struct sdp_session *sess,
-			       enum sdp_bandwidth type);
+				enum sdp_bandwidth type);
 int32_t sdp_session_rbandwidth(const struct sdp_session *sess,
-			       enum sdp_bandwidth type);
+				enum sdp_bandwidth type);
 const char *sdp_session_rattr(const struct sdp_session *sess,
-			      const char *name);
+				const char *name);
 const char *sdp_session_rattr_apply(const struct sdp_session *sess,
-				    const char *name,
-				    sdp_attr_h *attrh, void *arg);
+				const char *name,
+				sdp_attr_h *attrh, void *arg);
 const struct list *sdp_session_medial(const struct sdp_session *sess,
-				      bool local);
-int  sdp_session_debug(struct re_printf *pf, const struct sdp_session *sess);
+				bool local);
+int  sdp_session_debug(struct re_printf *pf,
+				const struct sdp_session *sess);
+int  sdp_session_json_api(struct odict *ods,
+				const struct sdp_session *sess);
 
 
 /* media */
@@ -133,6 +137,7 @@ const char *sdp_media_rattr_apply(const struct sdp_media *m, const char *name,
 				  sdp_attr_h *attrh, void *arg);
 const char *sdp_media_name(const struct sdp_media *m);
 int  sdp_media_debug(struct re_printf *pf, const struct sdp_media *m);
+int  sdp_media_json_api(struct odict *mod, const struct sdp_media *m);
 
 
 /* format */
@@ -145,6 +150,7 @@ int  sdp_format_set_params(struct sdp_format *fmt, const char *params, ...);
 bool sdp_format_cmp(const struct sdp_format *fmt1,
 		    const struct sdp_format *fmt2);
 int  sdp_format_debug(struct re_printf *pf, const struct sdp_format *fmt);
+int  sdp_format_json_api(struct odict *od, const struct sdp_format *fmt);
 
 
 /* encode/decode */

--- a/src/sdp/attr.c
+++ b/src/sdp/attr.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <string.h>
+#include <ctype.h>
 #include <re_types.h>
 #include <re_fmt.h>
 #include <re_mem.h>
@@ -12,6 +13,7 @@
 #include <re_sa.h>
 #include <re_sdp.h>
 #include "sdp.h"
+#include "re_odict.h"
 
 
 struct sdp_attr {
@@ -137,4 +139,39 @@ int sdp_attr_debug(struct re_printf *pf, const struct sdp_attr *attr)
 		return re_hprintf(pf, "%s='%s'", attr->name, attr->val);
 	else
 		return re_hprintf(pf, "%s", attr->name);
+}
+
+
+/**
+ * Print attributes from SDP format information in JSON
+ *
+ * @param od   SDP attribute dict
+ * @param attr SDP attribute
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int sdp_attr_json_api(struct odict *od, const struct sdp_attr *attr)
+{
+	int err = 0;
+
+	if (!attr)
+		return 0;
+
+	if (attr->val) {
+		/*
+		TODO: not working properly
+		if (isdigit(*attr->val)) {
+			err |= odict_entry_add(od, attr->name, ODICT_INT,
+				   (int64_t)attr->val - '0');
+		} else {
+			err |= odict_entry_add(od, attr->name, ODICT_STRING,
+				   attr->val);
+		}*/
+		err |= odict_entry_add(od, attr->name, ODICT_STRING,
+				   attr->val);
+	} else {
+		err |= odict_entry_add(od, attr->name, ODICT_BOOL, true);
+	}
+
+	return err;
 }

--- a/src/sdp/format.c
+++ b/src/sdp/format.c
@@ -13,6 +13,7 @@
 #include <re_sa.h>
 #include <re_sdp.h>
 #include "sdp.h"
+#include "re_odict.h"
 
 
 static void destructor(void *arg)
@@ -262,5 +263,45 @@ int sdp_format_debug(struct re_printf *pf, const struct sdp_format *fmt)
 	if (fmt->sup)
 		err |= re_hprintf(pf, " *");
 
+	return err;
+}
+
+
+/**
+ * Print SDP Format information in JSON
+ *
+ * @param od  Media format dict
+ * @param fmt SDP Format
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int sdp_format_json_api(struct odict *od, const struct sdp_format *fmt)
+{
+	struct odict *arrd = NULL;
+	int err = 0;
+
+	if (!fmt)
+		return 0;
+
+	err |= odict_alloc(&arrd, 8);
+
+	/* TODO: can we find out whats the
+			current negotiated algorithm one */
+
+	err |= odict_entry_add(arrd, "name", ODICT_STRING,
+			fmt->name ? fmt->name : "unknown");
+	err |= odict_entry_add(arrd, "sample_rate", ODICT_INT,
+			fmt->srate ? (int64_t)fmt->srate : 0);
+	err |= odict_entry_add(arrd, "channels", ODICT_INT,
+			fmt->ch ? (int64_t)fmt->ch : 0);
+	err |= odict_entry_add(arrd, "parameters", ODICT_STRING,
+			fmt->params ? fmt->params : "");
+	err |= odict_entry_add(arrd, "supported", ODICT_BOOL,
+			fmt->sup ? true : false);
+
+	err |= odict_entry_add(arrd, "id", ODICT_STRING, fmt->id);
+	err |= odict_entry_add(od, fmt->id, ODICT_ARRAY, arrd);
+
+	mem_deref(arrd);
 	return err;
 }

--- a/src/sdp/sdp.h
+++ b/src/sdp/sdp.h
@@ -1,7 +1,7 @@
 /**
  * @file sdp.h  Internal SDP interface
  *
- * Copyright (C) 2010 Creytiv.com
+ * Copyright (C) 2020 Creytiv.com
  */
 
 
@@ -85,3 +85,4 @@ const char *sdp_attr_apply(const struct list *lst, const char *name,
 			   sdp_attr_h *attrh, void *arg);
 int sdp_attr_print(struct re_printf *pf, const struct sdp_attr *attr);
 int sdp_attr_debug(struct re_printf *pf, const struct sdp_attr *attr);
+int sdp_attr_json_api(struct odict *od, const struct sdp_attr *attr);


### PR DESCRIPTION
Hi @alfredh !
This pull-request is dependent on [JSON codec call & sdp state command and response #999](https://github.com/baresip/baresip/pull/999) for the baresip library.

- added sdp_session_json_api method to session.c
- added sdp_media_json_api method to media.c
- added sdp_format_json_api method to format.c
- added sdp_attr_json_api method to attr.c

Hopefully this one is done properly!

Best regards
Roger