### PR TITLE
Fix for the fact that windows file descriptors do not follow possix numbering standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,67 @@ compiler:
     - clang
     - gcc
 
+jobs:                                                                                                                                                                                         
+  include:
+      - os: linux
+        stage: ccheck
+        addons:
+          apt:
+            update: false
+        script:
+          - wget "https://raw.githubusercontent.com/baresip/baresip/master/test/ccheck.py"
+          - python3 ccheck.py
+      - name: OpenSSL 1.0.2g
+        os: linux
+        dist: xenial
+        stage: openssl
+      - name: OpenSSL 1.1.1f
+        os: linux
+        dist: focal
+        stage: openssl
+      - name: macOS 10.15.5
+        os: osx
+        osx_image: xcode12.0
+        stage: openssl
+      - name: LibreSSL
+        os: linux
+        dist: xenial
+        script:
+          - wget "https://github.com/baresip/ci/releases/download/v0.1/assets.tar.gz"
+          - tar -xf assets.tar.gz
+          - make EXTRA_CFLAGS="-Iassets/libressl/include -Werror" EXTRA_LFLAGS="-Lassets/libressl" CCACHE=;
+        stage: openssl
+      - name: OpenSSL 1.1.1g no-deprecated
+        os: linux
+        dist: xenial
+        script:
+          - wget "https://github.com/baresip/ci/releases/download/v0.1/assets.tar.gz"
+          - tar -xf assets.tar.gz
+          - make EXTRA_CFLAGS="-Iassets/openssl/include -Werror" EXTRA_LFLAGS="-Lassets/openssl" CCACHE=;
+        stage: openssl
+
+
+stages:
+  - ccheck
+  - test
+  - openssl
+
 addons:
   apt:
     packages:
       libssl-dev
 
-install:
-    - wget "https://github.com/alfredh/pytools/raw/master/ccheck.py"
-
 script: 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         make EXTRA_CFLAGS=-Werror CCACHE=;
     fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        cd ..; rm re/libre.so;
+        git clone https://github.com/creytiv/rem;
+        make -C rem librem.a;
+        git clone https://github.com/baresip/retest.git;
+        cd retest && make STATIC=1 LIBRE_SO=../re && ./retest -r;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         make EXTRA_CFLAGS="-I/usr/local/opt/openssl/include -Werror" EXTRA_LFLAGS="-L/usr/local/opt/openssl/lib" CCACHE=;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python2 ccheck.py ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# libre Changelog
+
+All notable changes to libre will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.0.0] - 2020-09-08
+
+### Added
+
+- sip: add trace
+- sdp: sdp_media_disabled API function [#2]
+- tls: add tls_set_selfsigned_rsa [#6]
+- tls: add functions to verify server cert, purpose and hostname [#10]
+- http: client should set SNI [#10]
+- http: client should use tls functions to verify server certs, purpose
+  and hostname [#10]
+- sipreg: add proxy expires field and get function [#13]
+- sipreg: make re-register interval configurable [#13]
+
+### Changed
+
+- debian: Automatic cleanup after building debian package
+
+### Fixed
+
+- Set SDK path (SYSROOT) using xcrun (fix building on macOS 10.14)
+- tcp: close socket on windows if connection is aborted or reset [#1]
+- rtmp: Fix URL path parsing (creytiv#245)
+- ice: various fixes [baresip/baresip#925]
+- openssl/tls: replace deprecated openssl 1.1.0 functions [#5]
+
+### Contributors (many thanks)
+
+- Alfred E. Heggestad
+- Christian Spielberger
+- Christoph Huber
+- Franz Auernigg
+- juha-h
+- Juha Heinanen
+- Richard Aas
+- Sebastian Reimers
+
+[#13]: https://github.com/baresip/re/pull/13
+[#10]: https://github.com/baresip/re/pull/10
+[#6]: https://github.com/baresip/re/pull/6
+[#5]: https://github.com/baresip/re/pull/5
+[#2]: https://github.com/baresip/re/pull/2
+[#1]: https://github.com/baresip/re/pull/1
+
+[v1.0.0]: https://github.com/baresip/re/compare/v0.6.1...v1.0.0
+[Unreleased]: https://github.com/baresip/re/compare/v1.0.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@
 #
 
 # Master version number
-VER_MAJOR := 0
-VER_MINOR := 6
-VER_PATCH := 1
+VER_MAJOR := 1
+VER_MINOR := 0
+VER_PATCH := 0
 
 PROJECT   := re
 VERSION   := $(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ libre README
 
 
 libre is a Generic library for real-time communications with async IO support.
-Copyright (C) 2010 - 2019 Creytiv.com
+Copyright (C) 2010 - 2020 Creytiv.com
 
 
-[![Build Status](https://travis-ci.org/creytiv/re.svg?branch=master)](https://travis-ci.org/creytiv/re)
+[![Build Status](https://travis-ci.org/baresip/re.svg?branch=master)](https://travis-ci.org/baresip/re)
 
 
 ## Features
@@ -79,7 +79,7 @@ The libre project is using the BSD license.
 ## Contributing
 
 Patches can sent via Github
-[Pull-Requests](https://github.com/creytiv/re/pulls) or to the RE devel
+[Pull-Requests](https://github.com/baresip/re/pulls) or to the RE devel
 [mailing-list](http://lists.creytiv.com/mailman/listinfo/re-devel).
 Currently we only accept small patches.
 Please send private feedback to libre [at] creytiv.com
@@ -278,8 +278,8 @@ legend:
 ## Related projects
 
 * [librem](https://github.com/creytiv/rem)
-* [retest](https://github.com/creytiv/retest)
-* [baresip](https://github.com/alfredh/baresip)
+* [retest](https://github.com/baresip/retest)
+* [baresip](https://github.com/baresip/baresip)
 * [restund](http://creytiv.com/restund.html)
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libre (1.0.0) unstable; urgency=medium
+
+  * version 1.0.0
+
+ -- Sebastian Reimers <sebastian.reimers@gmail.com>  Thu, 08 Sep 2020 08:00:00 +0200
+
 libre (0.6.1-3) unstable; urgency=medium
 
   * version 0.6.1-3

--- a/include/re_http.h
+++ b/include/re_http.h
@@ -125,6 +125,9 @@ typedef void (http_conn_h)(struct tcp_conn *tc, struct tls_conn *sc,
 			   void *arg);
 
 int http_client_alloc(struct http_cli **clip, struct dnsc *dnsc);
+int http_client_add_ca(struct http_cli *cli, const char *tls_ca);
+int http_client_set_tls_hostname(struct http_cli *cli,
+				 const struct pl *hostname);
 int http_request(struct http_req **reqp, struct http_cli *cli, const char *met,
 		 const char *uri, http_resp_h *resph, http_data_h *datah,
 		 void *arg, const char *fmt, ...);

--- a/include/re_ice.h
+++ b/include/re_ice.h
@@ -24,12 +24,6 @@ enum ice_compid {
 	ICE_COMPID_RTCP = 2
 };
 
-/** ICE Nomination */
-enum ice_nomination {
-	ICE_NOMINATION_REGULAR = 0,
-	ICE_NOMINATION_AGGRESSIVE
-};
-
 /** ICE Candidate type */
 enum ice_cand_type {
 	ICE_CAND_TYPE_HOST,   /**< Host candidate             */
@@ -61,7 +55,6 @@ struct turnc;
 
 /** ICE Configuration */
 struct ice_conf {
-	enum ice_nomination nom;  /**< Nomination algorithm        */
 	uint32_t rto;             /**< STUN Retransmission TimeOut */
 	uint32_t rc;              /**< STUN Retransmission Count   */
 	bool debug;               /**< Enable ICE debugging        */
@@ -84,7 +77,6 @@ int  icem_comp_add(struct icem *icem, unsigned compid, void *sock);
 int  icem_cand_add(struct icem *icem, unsigned compid, uint16_t lprio,
 		   const char *ifname, const struct sa *addr);
 
-int  icem_lite_set_default_candidates(struct icem *icem);
 bool icem_verify_support(struct icem *icem, unsigned compid,
 			 const struct sa *raddr);
 int  icem_conncheck_start(struct icem *icem);

--- a/include/re_sdp.h
+++ b/include/re_sdp.h
@@ -91,6 +91,7 @@ int  sdp_media_set_alt_protos(struct sdp_media *m, unsigned protoc, ...);
 void sdp_media_set_encode_handler(struct sdp_media *m, sdp_media_enc_h *ench,
 				  void *arg);
 void sdp_media_set_fmt_ignore(struct sdp_media *m, bool fmt_ignore);
+bool sdp_media_disabled(struct sdp_media *m);
 void sdp_media_set_disabled(struct sdp_media *m, bool disabled);
 void sdp_media_set_lport(struct sdp_media *m, uint16_t port);
 void sdp_media_set_laddr(struct sdp_media *m, const struct sa *laddr);

--- a/include/re_sip.h
+++ b/include/re_sip.h
@@ -242,6 +242,11 @@ typedef bool(sip_hdr_h)(const struct sip_hdr *hdr, const struct sip_msg *msg,
 			void *arg);
 typedef void(sip_keepalive_h)(int err, void *arg);
 
+#define LIBRE_HAVE_SIPTRACE 1
+typedef void(sip_trace_h)(bool tx, enum sip_transp tp,
+			  const struct sa *src, const struct sa *dst,
+			  const uint8_t *pkt, size_t len, void *arg);
+
 
 /* sip */
 int  sip_alloc(struct sip **sipp, struct dnsc *dnsc, uint32_t ctsz,
@@ -253,6 +258,7 @@ int  sip_listen(struct sip_lsnr **lsnrp, struct sip *sip, bool req,
 int  sip_debug(struct re_printf *pf, const struct sip *sip);
 int  sip_send(struct sip *sip, void *sock, enum sip_transp tp,
 	      const struct sa *dst, struct mbuf *mb);
+void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh);
 
 
 /* transport */

--- a/include/re_sipreg.h
+++ b/include/re_sipreg.h
@@ -15,4 +15,8 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 		    sip_resp_h *resph, void *arg,
 		    const char *params, const char *fmt, ...);
 
+int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait);
+
 const struct sa *sipreg_laddr(const struct sipreg *reg);
+
+uint32_t sipreg_proxy_expires(const struct sipreg *reg);

--- a/include/re_tls.h
+++ b/include/re_tls.h
@@ -34,6 +34,7 @@ int tls_alloc(struct tls **tlsp, enum tls_method method, const char *keyfile,
 	      const char *pwd);
 int tls_add_ca(struct tls *tls, const char *cafile);
 int tls_set_selfsigned(struct tls *tls, const char *cn);
+int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits);
 int tls_set_certificate_pem(struct tls *tls, const char *cert, size_t len_cert,
 			    const char *key, size_t len_key);
 int tls_set_certificate_der(struct tls *tls, enum tls_keytype keytype,
@@ -48,6 +49,9 @@ int tls_fingerprint(const struct tls *tls, enum tls_fingerprint type,
 int tls_peer_fingerprint(const struct tls_conn *tc, enum tls_fingerprint type,
 			 uint8_t *md, size_t size);
 int tls_peer_common_name(const struct tls_conn *tc, char *cn, size_t size);
+int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname);
+int tls_set_verify_purpose(struct tls *tls, const char *purpose);
+int tls_set_hostname(char *tls_hostname, const struct pl *hostname);
 int tls_peer_verify(const struct tls_conn *tc);
 int tls_srtp_keyinfo(const struct tls_conn *tc, enum srtp_suite *suite,
 		     uint8_t *cli_key, size_t cli_key_size,
@@ -57,6 +61,8 @@ int tls_set_ciphers(struct tls *tls, const char *cipherv[], size_t count);
 int tls_set_servername(struct tls_conn *tc, const char *servername);
 int tls_set_verify_server(struct tls_conn *tc, const char *host);
 
+int tls_get_issuer(struct tls *tls, struct mbuf *mb);
+int tls_get_subject(struct tls *tls, struct mbuf *mb);
 
 /* TCP */
 

--- a/rpm/re.spec
+++ b/rpm/re.spec
@@ -1,5 +1,5 @@
 %define name     re
-%define ver      0.6.1
+%define ver      1.0.0
 %define rel      1
 
 Summary: Generic library for real-time communications with async IO support

--- a/src/ice/chklist.c
+++ b/src/ice/chklist.c
@@ -163,12 +163,6 @@ int icem_checklist_form(struct icem *icem)
 	if (!icem)
 		return EINVAL;
 
-	if (ICE_MODE_LITE == icem->lmode) {
-		DEBUG_WARNING("%s: Checklist: only valid for full-mode\n",
-			      icem->name);
-		return EINVAL;
-	}
-
 	if (!list_isempty(&icem->checkl))
 		return EALREADY;
 
@@ -211,6 +205,7 @@ static bool iscompleted(const struct icem *icem)
 static void concluding_ice(struct icem_comp *comp)
 {
 	struct ice_candpair *cp;
+	bool use_cand;
 
 	if (!comp || comp->concluded)
 		return;
@@ -228,12 +223,13 @@ static void concluding_ice(struct icem_comp *comp)
 
 	icem_comp_set_selected(comp, cp);
 
-	if (comp->icem->conf.nom == ICE_NOMINATION_REGULAR) {
+	/* Regular nomination */
 
-		/* send STUN request with USE_CAND flag via triggered qeueue */
-		(void)icem_conncheck_send(cp, true, true);
-		icem_conncheck_schedule_check(comp->icem);
-	}
+	use_cand = comp->icem->lrole == ICE_ROLE_CONTROLLING;
+
+	/* send STUN request with USE_CAND flag via triggered qeueue */
+	(void)icem_conncheck_send(cp, use_cand, true);
+	icem_conncheck_schedule_check(comp->icem);
 
 	comp->concluded = true;
 }

--- a/src/ice/comp.c
+++ b/src/ice/comp.c
@@ -199,9 +199,11 @@ void icem_comp_set_selected(struct icem_comp *comp, struct ice_candpair *cp)
 		return;
 
 	if (cp->state != ICE_CANDPAIR_SUCCEEDED) {
-		DEBUG_WARNING("{%s.%u} set_selected: invalid state %s\n",
+		DEBUG_WARNING("{%s.%u} set_selected: invalid state '%s'"
+			      " [%H]\n",
 			      comp->icem->name, comp->id,
-			      ice_candpair_state2name(cp->state));
+			      ice_candpair_state2name(cp->state),
+			      icem_candpair_debug, cp);
 	}
 
 	mem_deref(comp->cp_sel);

--- a/src/ice/connchk.c
+++ b/src/ice/connchk.c
@@ -225,13 +225,18 @@ int icem_conncheck_send(struct ice_candpair *cp, bool use_cand, bool trigged)
 
 	case ICE_ROLE_CONTROLLING:
 		ctrl_attr = STUN_ATTR_CONTROLLING;
-
-		if (icem->conf.nom == ICE_NOMINATION_AGGRESSIVE)
-			use_cand = true;
 		break;
 
 	case ICE_ROLE_CONTROLLED:
 		ctrl_attr = STUN_ATTR_CONTROLLED;
+
+		if (use_cand) {
+			DEBUG_WARNING("send: use_cand=true, but"
+				      " role is controlled (trigged=%d)"
+				      " [%H]\n", trigged,
+				      icem_candpair_debug, cp);
+			return EINVAL;
+		}
 		break;
 
 	default:
@@ -394,9 +399,6 @@ int icem_conncheck_start(struct icem *icem)
 	int err;
 
 	if (!icem)
-		return EINVAL;
-
-	if (ICE_MODE_FULL != icem->lmode)
 		return EINVAL;
 
 	err = icem_checklist_form(icem);

--- a/src/ice/ice.h
+++ b/src/ice/ice.h
@@ -60,7 +60,6 @@ struct icem {
 	struct list validl;          /**< Valid List of cand pairs (sorted)  */
 	uint64_t tiebrk;             /**< Tie-break value for roleconflict   */
 	bool mismatch;               /**< ICE mismatch flag                  */
-	enum ice_mode lmode;         /**< Local mode                         */
 	enum ice_mode rmode;         /**< Remote mode                        */
 	enum ice_role lrole;         /**< Local role                         */
 	struct tmr tmr_pace;         /**< Timer for pacing STUN requests     */

--- a/src/ice/icesdp.c
+++ b/src/ice/icesdp.c
@@ -265,10 +265,6 @@ int ice_sdp_decode(struct icem *icem, const char *name, const char *value)
 		return EINVAL;
 
 	if (0 == str_casecmp(name, ice_attr_lite)) {
-		if (ICE_MODE_LITE == icem->lmode) {
-			DEBUG_WARNING("we are lite, peer is also lite!\n");
-			return EPROTO;
-		}
 		icem->rmode = ICE_MODE_LITE;
 		icem->lrole = ICE_ROLE_CONTROLLING;
 	}

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -83,15 +83,17 @@ enum {
 #endif
 };
 
+/** File descriptor handler struct */
+struct fhs {
+	int fd;              /**< File Descriptor                   */
+	int flags;           /**< Polling flags (Read, Write, etc.) */
+	fd_h* fh;            /**< Event handler                     */
+	void* arg;           /**< Handler argument                  */
+};
 
 /** Polling loop data */
 struct re {
-	/** File descriptor handler set */
-	struct {
-		int flags;           /**< Polling flags (Read, Write, etc.) */
-		fd_h *fh;            /**< Event handler                     */
-		void *arg;           /**< Handler argument                  */
-	} *fhs;
+	struct fhs *fhs;             /** File descriptor handler set        */
 	int maxfds;                  /**< Maximum number of polling fds     */
 	int nfds;                    /**< Number of active file descriptors */
 	enum poll_method method;     /**< The current polling method        */
@@ -221,6 +223,19 @@ static struct re *re_get(void)
 
 #endif
 
+#ifdef WIN32
+static int lookup_fd_index(struct re* re, int fd) {
+	int i = 0;
+	int lim = fd == 0 ? re->maxfds : re->nfds;
+
+	for (i = 0; i < lim; i++) {
+		if (re->fhs[i].fd == fd)
+			return i;
+	}
+
+	return -1;
+}
+#endif
 
 #if MAIN_DEBUG
 /**
@@ -230,21 +245,21 @@ static struct re *re_get(void)
  * @param fd     File descriptor
  * @param flags  Event flags
  */
-static void fd_handler(struct re *re, int fd, int flags)
+static void fd_handler(struct re *re, int i, int flags)
 {
 	const uint64_t tick = tmr_jiffies();
 	uint32_t diff;
 
-	DEBUG_INFO("event on fd=%d (flags=0x%02x)...\n", fd, flags);
+	DEBUG_INFO("event on fd=%d (flags=0x%02x)...\n", re->fhs[i].fd, flags);
 
-	re->fhs[fd].fh(flags, re->fhs[fd].arg);
+	re->fhs[i].fh(flags, re->fhs[i].arg);
 
 	diff = (uint32_t)(tmr_jiffies() - tick);
 
 	if (diff > MAX_BLOCKING) {
 		DEBUG_WARNING("long async blocking: %u>%u ms (h=%p arg=%p)\n",
 			      diff, MAX_BLOCKING,
-			      re->fhs[fd].fh, re->fhs[fd].arg);
+			      re->fhs[i].fh, re->fhs[i].arg);
 	}
 }
 #endif
@@ -565,6 +580,7 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 {
 	struct re *re = re_get();
 	int err = 0;
+	int i = fd;
 
 	DEBUG_INFO("fd_listen: fd=%d flags=0x%02x\n", fd, flags);
 
@@ -579,7 +595,18 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 			return err;
 	}
 
-	if (fd >= re->maxfds) {
+#ifdef WIN32
+	// Windows file descriptors do not follow possix standard ranges.
+	// This code emulates possix numbering. There is no locking, so zero thread-safety.
+	// FRirst a linear search through the list of file handles to find existing descriptor.
+	i = lookup_fd_index(re, fd);
+	if (i == -1) {
+		// And if nothing is found a linear search for the first zeroed handler
+		i = lookup_fd_index(re, 0);
+	}
+#endif // #ifdef WIN32
+
+	if (i >= re->maxfds) {
 		if (flags) {
 			DEBUG_WARNING("fd_listen: fd=%d flags=0x%02x"
 				      " - Max %d fds\n",
@@ -590,12 +617,13 @@ int fd_listen(int fd, int flags, fd_h *fh, void *arg)
 
 	/* Update fh set */
 	if (re->fhs) {
-		re->fhs[fd].flags = flags;
-		re->fhs[fd].fh    = fh;
-		re->fhs[fd].arg   = arg;
+		re->fhs[i].fd    = fd;
+		re->fhs[i].flags = flags;
+		re->fhs[i].fh    = fh;
+		re->fhs[i].arg   = arg;
 	}
 
-	re->nfds = max(re->nfds, fd+1);
+	re->nfds = max(re->nfds, i+1);
 
 	switch (re->method) {
 
@@ -683,15 +711,16 @@ static int fd_poll(struct re *re)
 		FD_ZERO(&efds);
 
 		for (i=0; i<re->nfds; i++) {
+			int fd = re->fhs[i].fd;
 			if (!re->fhs[i].fh)
 				continue;
 
 			if (re->fhs[i].flags & FD_READ)
-				FD_SET(i, &rfds);
+				FD_SET(fd, &rfds);
 			if (re->fhs[i].flags & FD_WRITE)
-				FD_SET(i, &wfds);
+				FD_SET(fd, &wfds);
 			if (re->fhs[i].flags & FD_EXCEPT)
-				FD_SET(i, &efds);
+				FD_SET(fd, &efds);
 		}
 
 #ifdef WIN32
@@ -767,13 +796,15 @@ static int fd_poll(struct re *re)
 #endif
 #ifdef HAVE_SELECT
 		case METHOD_SELECT:
-			fd = i;
-			if (FD_ISSET(fd, &rfds))
-				flags |= FD_READ;
-			if (FD_ISSET(fd, &wfds))
-				flags |= FD_WRITE;
-			if (FD_ISSET(fd, &efds))
-				flags |= FD_EXCEPT;
+			fd = re->fhs[i].fd;
+			if (fd) {
+				if (FD_ISSET(fd, &rfds))
+					flags |= FD_READ;
+				if (FD_ISSET(fd, &wfds))
+					flags |= FD_WRITE;
+				if (FD_ISSET(fd, &efds))
+					flags |= FD_EXCEPT;
+			}
 			break;
 #endif
 #ifdef HAVE_EPOLL
@@ -838,11 +869,11 @@ static int fd_poll(struct re *re)
 		if (!flags)
 			continue;
 
-		if (re->fhs[fd].fh) {
+		if (re->fhs[i].fh) {
 #if MAIN_DEBUG
-			fd_handler(re, fd, flags);
+			fd_handler(re, i, flags);
 #else
-			re->fhs[fd].fh(flags, re->fhs[fd].arg);
+			re->fhs[i].fh(flags, re->fhs[i].arg);
 #endif
 		}
 

--- a/src/main/openssl.c
+++ b/src/main/openssl.c
@@ -149,8 +149,15 @@ int openssl_init(void)
 	(void)signal(SIGPIPE, sigpipe_handler);
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	int err;
+	err = OPENSSL_init_ssl(OPENSSL_INIT_SSL_DEFAULT, NULL);
+	if (!err)
+		return !err;
+#else
 	SSL_library_init();
 	SSL_load_error_strings();
+#endif
 
 	return 0;
 }
@@ -158,7 +165,9 @@ int openssl_init(void)
 
 void openssl_close(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ERR_free_strings();
+#endif
 #if defined (HAVE_PTHREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
 	lockv = mem_deref(lockv);
 #endif

--- a/src/sdp/media.c
+++ b/src/sdp/media.c
@@ -421,6 +421,22 @@ void sdp_media_set_disabled(struct sdp_media *m, bool disabled)
 
 
 /**
+ * Check if an SDP Media line is disabled
+ *
+ * @param  m SDP Media line
+ * @return True if disabled, otherwise false
+
+ */
+bool sdp_media_disabled(struct sdp_media *m)
+{
+	if (!m)
+		return true;
+
+	return m->disabled;
+}
+
+
+/**
  * Set the local port number of an SDP Media line
  *
  * @param m    SDP Media line

--- a/src/sip/sip.c
+++ b/src/sip/sip.c
@@ -236,3 +236,12 @@ int sip_debug(struct re_printf *pf, const struct sip *sip)
 
 	return err;
 }
+
+
+void sip_set_trace_handler(struct sip *sip, sip_trace_h *traceh)
+{
+	if (!sip)
+		return;
+
+	sip->traceh = traceh;
+}

--- a/src/sip/sip.h
+++ b/src/sip/sip.h
@@ -18,6 +18,7 @@ struct sip {
 	struct stun *stun;
 	char *software;
 	sip_exit_h *exith;
+	sip_trace_h *traceh;
 	void *arg;
 	bool closing;
 };

--- a/src/sipreg/reg.c
+++ b/src/sipreg/reg.c
@@ -38,7 +38,9 @@ struct sipreg {
 	sip_resp_h *resph;
 	void *arg;
 	uint32_t expires;
+	uint32_t pexpires;
 	uint32_t failc;
+	uint32_t rwait;
 	uint32_t wait;
 	enum sip_transp tp;
 	bool registered;
@@ -157,12 +159,12 @@ static bool contact_handler(const struct sip_hdr *hdr,
 		return false;
 
 	if (!msg_param_decode(&c.params, "expires", &pval)) {
-	        reg->wait = pl_u32(&pval);
+		reg->wait = pl_u32(&pval);
 	}
 	else if (pl_isset(&msg->expires))
-	        reg->wait = pl_u32(&msg->expires);
+		reg->wait = pl_u32(&msg->expires);
 	else
-	        reg->wait = DEFAULT_EXPIRES;
+		reg->wait = DEFAULT_EXPIRES;
 
 	return true;
 }
@@ -188,7 +190,8 @@ static void response_handler(int err, const struct sip_msg *msg, void *arg)
 		reg->wait = reg->expires;
 		sip_msg_hdr_apply(msg, true, SIP_HDR_CONTACT, contact_handler,
 				  reg);
-		reg->wait *= 900;
+		reg->pexpires = reg->wait;
+		reg->wait *= reg->rwait * (1000 / 100);
 		reg->failc = 0;
 
 		if (reg->regid > 0 && !reg->terminated && !reg->ka)
@@ -308,7 +311,7 @@ static int request(struct sipreg *reg, bool reset_ls)
  * @param to_uri   SIP To-header URI
  * @param from_name  SIP From-header display name (optional)
  * @param from_uri SIP From-header URI
- * @param expires  Registration interval in [seconds]
+ * @param expires  Registration expiry time in [seconds]
  * @param cuser    Contact username
  * @param routev   Optional route vector
  * @param routec   Number of routes
@@ -378,6 +381,7 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 
 	reg->sip     = mem_ref(sip);
 	reg->expires = expires;
+	reg->rwait   = 90;
 	reg->resph   = resph ? resph : dummy_handler;
 	reg->arg     = arg;
 	reg->regid   = regid;
@@ -397,6 +401,25 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 
 
 /**
+ * Set the relative registration interval in percent from proxy expiry time. A
+ * value from 5-95% is accepted.
+ *
+ * @param reg   SIP Registration client
+ * @param rwait The relative registration interval in [%].
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int sipreg_set_rwait(struct sipreg *reg, uint32_t rwait)
+{
+	if (!reg || rwait < 5 || rwait > 95)
+		return EINVAL;
+
+	reg->rwait = rwait;
+	return 0;
+}
+
+
+/**
  * Get the local socket address for a SIP Registration client
  *
  * @param reg SIP Registration client
@@ -406,4 +429,17 @@ int sipreg_register(struct sipreg **regp, struct sip *sip, const char *reg_uri,
 const struct sa *sipreg_laddr(const struct sipreg *reg)
 {
 	return reg ? &reg->laddr : NULL;
+}
+
+
+/**
+ * Get the proxy expires value of a SIP registration client
+ *
+ * @param reg SIP registration client
+ *
+ * @return the proxy expires value
+ */
+uint32_t sipreg_proxy_expires(const struct sipreg *reg)
+{
+	return reg ? reg->pexpires : 0;
 }

--- a/src/tcp/tcp.c
+++ b/src/tcp/tcp.c
@@ -377,7 +377,17 @@ static void tcp_recv_handler(int flags, void *arg)
 		return;
 	}
 	else if (n < 0) {
+#ifdef WIN32
+		err = WSAGetLastError();
+		DEBUG_WARNING("recv handler: recv(): %d\n", err);
+		if (err == WSAECONNRESET || err == WSAECONNABORTED) {
+			mem_deref(mb);
+			conn_close(tc, err);
+			return;
+		}
+#else
 		DEBUG_WARNING("recv handler: recv(): %m\n", errno);
+#endif
 		goto out;
 	}
 

--- a/src/tls/openssl/tls.c
+++ b/src/tls/openssl/tls.c
@@ -230,6 +230,90 @@ int tls_add_ca(struct tls *tls, const char *cafile)
 
 
 /**
+ * Set SSL verification of the certificate purpose
+ *
+ * @param tls     TLS Context
+ * @param purpose Certificate purpose as string
+ *
+ * @return int    0 if success, errorcode otherwise
+ */
+int tls_set_verify_purpose(struct tls *tls, const char *purpose)
+{
+	int err;
+	int i;
+	X509_PURPOSE *xptmp;
+
+	if (!tls || !purpose)
+		return EINVAL;
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	i = X509_PURPOSE_get_by_sname(purpose);
+#else
+	i = X509_PURPOSE_get_by_sname((char *) purpose);
+#endif
+
+	if (i < 0)
+		return EINVAL;
+
+	/* purpose index -> purpose object */
+	/* purpose object -> purpose value */
+	xptmp = X509_PURPOSE_get0(i);
+	i = X509_PURPOSE_get_id(xptmp);
+	err = SSL_CTX_set_purpose(tls->ctx, i);
+
+	return err == 1 ? 0 : EINVAL;
+}
+
+
+/**
+ * Set SSL verification of hostname
+ *
+ * @param tc       TLS Connection
+ * @param hostname Certificate hostname
+ *
+ * @return int     0 if success, errorcode otherwise
+ */
+int tls_peer_set_verify_host(struct tls_conn *tc, const char *hostname)
+{
+	int err = 0;
+
+	if (!tc)
+		return EINVAL;
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	err = SSL_set1_host(tc->ssl, hostname);
+#else
+	DEBUG_WARNING("verify hostname needs openssl version 1.1.0\n");
+	return ENOSYS;
+#endif
+
+	return err == 1 ? 0 : EINVAL;
+}
+
+
+/**
+ * Convert string hostname to pl hostname
+ *
+ * @param tls_hostname Certificate hostname as string
+ * @param hostname     Certificate hostname as pl
+ *
+ * @return int         0 if success, errorcode otherwise
+ */
+int tls_set_hostname(char *tls_hostname, const struct pl *hostname)
+{
+	if (!tls_hostname || !hostname)
+		return EINVAL;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	DEBUG_WARNING("verify hostname needs openssl version 1.1.0\n");
+	return ENOSYS;
+#endif
+
+	return pl_strdup(&tls_hostname, hostname);
+}
+
+
+/**
  * Generate and set selfsigned certificate on TLS context
  *
  * @param tls TLS Context
@@ -238,6 +322,12 @@ int tls_add_ca(struct tls *tls, const char *cafile)
  * @return 0 if success, otherwise errorcode
  */
 int tls_set_selfsigned(struct tls *tls, const char *cn)
+{
+	return tls_set_selfsigned_rsa(tls, cn, 1024);
+}
+
+
+int tls_set_selfsigned_rsa(struct tls *tls, const char *cn, size_t bits)
 {
 	X509_NAME *subj = NULL;
 	EVP_PKEY *key = NULL;
@@ -258,7 +348,7 @@ int tls_set_selfsigned(struct tls *tls, const char *cn)
 		goto out;
 
 	BN_set_word(bn, RSA_F4);
-	if (!RSA_generate_key_ex(rsa, 1024, bn, NULL))
+	if (!RSA_generate_key_ex(rsa, (int)bits, bn, NULL))
 		goto out;
 
 	key = EVP_PKEY_new();
@@ -291,9 +381,15 @@ int tls_set_selfsigned(struct tls *tls, const char *cn)
 	    !X509_set_subject_name(cert, subj))
 		goto out;
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	if (!X509_gmtime_adj(X509_getm_notBefore(cert), -3600*24*365) ||
+	    !X509_gmtime_adj(X509_getm_notAfter(cert),   3600*24*365*10))
+		goto out;
+#else
 	if (!X509_gmtime_adj(X509_get_notBefore(cert), -3600*24*365) ||
 	    !X509_gmtime_adj(X509_get_notAfter(cert),   3600*24*365*10))
 		goto out;
+#endif
 
 	if (!X509_set_pubkey(cert, key))
 		goto out;
@@ -936,4 +1032,130 @@ void tls_flush_error(void)
 struct ssl_ctx_st *tls_openssl_context(const struct tls *tls)
 {
 	return tls ? tls->ctx : NULL;
+}
+
+
+/**
+ * Convert a X509_NAME object into a human-readable form placed in an mbuf
+ *
+ * @param field  X509_NAME of Cert field
+ * @param mb     Memorybuffer to store the readable format
+ * @param flags  X509_NAME_print_ex flags
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int convert_X509_NAME_to_mbuf(X509_NAME *field, struct mbuf *mb,
+	unsigned long flags)
+{
+	BIO *outbio;
+	char *p;
+	long size;
+	int err = ENOMEM;
+
+	if (!field || !mb)
+		return EINVAL;
+
+	outbio = BIO_new(BIO_s_mem());
+	if (!outbio)
+		return ENOMEM;
+
+	if (X509_NAME_print_ex(outbio, field, 1, flags) <= 0)
+		goto out;
+
+	if (BIO_eof(outbio))
+		goto out;
+
+	size = BIO_get_mem_data(outbio, &p);
+	err = mbuf_write_mem(mb, (uint8_t *)p, size);
+	if (err)
+		goto out;
+
+	err = 0;
+
+ out:
+	if (outbio)
+		BIO_free(outbio);
+
+	return err;
+}
+
+
+/**
+ * Extract a X509 certficate issuer/subject and write the result into an mbuf
+ *
+ * @param tls           TLS Object
+ * @param mb            Memory buffer
+ * @param field_getter  Functionpointer to the X509 getter functon
+ * @param flags         X509_NAME_print_ex flags
+ *
+ * @return 0 if success, othewise errorcode
+ */
+static int tls_get_ca_chain_field(struct tls *tls, struct mbuf *mb,
+	tls_get_certfield_h *field_getter, unsigned long flags)
+{
+	STACK_OF(X509) *certstack;
+	X509 *cert;
+	X509_NAME *field;
+	int err = EINVAL;
+
+	if (!field_getter)
+		return EINVAL;
+
+	if (!SSL_CTX_get0_chain_certs(tls->ctx, &certstack) || !certstack)
+		goto out;
+
+	for (int i = 0; i < sk_X509_num(certstack); i++) {
+		cert = sk_X509_value(certstack, i);
+		if (!cert)
+			goto out;
+
+		field = field_getter(cert);
+		if (!field)
+			goto out;
+
+		err = convert_X509_NAME_to_mbuf(field, mb, flags);
+		if (err)
+			goto out;
+	}
+
+	err = 0;
+
+ out:
+	return err;
+}
+
+
+/**
+ * Get the issuers fields of a certificate chain
+ *
+ * @param tls  TLS Object
+ * @param mb   Memory Buffer
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_get_issuer(struct tls *tls, struct mbuf *mb)
+{
+	if (!tls || !tls->ctx || !mb)
+		return EINVAL;
+
+	return tls_get_ca_chain_field(tls, mb, &X509_get_issuer_name,
+		XN_FLAG_RFC2253);
+}
+
+
+/**
+ * Get the subject fields of a certificate chain
+ *
+ * @param tls  TLS Object
+ * @param mb   Memory Buffer
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int tls_get_subject(struct tls *tls, struct mbuf *mb)
+{
+	if (!tls || !tls->ctx || !mb)
+		return EINVAL;
+
+	return tls_get_ca_chain_field(tls, mb, &X509_get_subject_name,
+		XN_FLAG_RFC2253);
 }

--- a/src/tls/openssl/tls.h
+++ b/src/tls/openssl/tls.h
@@ -25,6 +25,13 @@
 #endif
 
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+typedef X509_NAME*(tls_get_certfield_h)(const X509 *);
+#else
+typedef X509_NAME*(tls_get_certfield_h)(X509 *);
+#endif
+
+
 struct tls {
 	SSL_CTX *ctx;
 	X509 *cert;


### PR DESCRIPTION
Hey

So I tried to build and run under windows, but calling kept failing in fd_listen due to out of bounds check on the file descriptor.
I was pointed to this change: https://github.com/creytiv/re/commit/49834b7afd0fe31660108271ef7657a34caa6a6d
But thought it was somewhat invasive.

I ended up making this change instead. It's pretty simple and consists mostly of renaming of variables to clearly distinguish between what is an index into fhs and what is an actual descriptor handle.

The only new thing is the windows-only lookup_fd_index which maps file descriptors to indices.

Baresip compiles and runs and makes calls, when build with this version on windows SDK 10.

I have not tested anything under linux, not even compilation.

If you're interested, I can make any recommended changes and test it under linux.

Cheers,
John
