### PR TITLE
Add hash_remove and use in transp to fix #261

### DIFF
--- a/include/re_hash.h
+++ b/include/re_hash.h
@@ -12,6 +12,7 @@ struct pl;
 int  hash_alloc(struct hash **hp, uint32_t bsize);
 void hash_append(struct hash *h, uint32_t key, struct le *le, void *data);
 void hash_unlink(struct le *le);
+void hash_remove(struct le *le);
 struct le *hash_lookup(const struct hash *h, uint32_t key, list_apply_h *ah,
 		       void *arg);
 struct le *hash_apply(const struct hash *h, list_apply_h *ah, void *arg);

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -96,6 +96,23 @@ void hash_unlink(struct le *le)
 
 
 /**
+ * If the element is present in the hashmap table, unlink it and deref the object,
+ * otherwise do nothing.  This is like hash_flush but for a single entry.
+ *
+ * @param le     List element
+ */
+void hash_remove(struct le *le)
+{
+	if (le->list != NULL)
+	{
+		void *data = le->data;
+		list_unlink(le);
+		mem_deref(data);
+	}
+}
+
+
+/**
  * Apply a handler function to all elements in the hashmap with a matching key
  *
  * @param h   Hashmap table

--- a/src/sip/transp.c
+++ b/src/sip/transp.c
@@ -175,7 +175,6 @@ static void conn_close(struct sip_conn *conn, int err)
 	conn->tc = mem_deref(conn->tc);
 	tmr_cancel(&conn->tmr_ka);
 	tmr_cancel(&conn->tmr);
-	hash_unlink(&conn->he);
 
 	le = list_head(&conn->ql);
 
@@ -195,6 +194,7 @@ static void conn_close(struct sip_conn *conn, int err)
 	}
 
 	sip_keepalive_signal(&conn->kal, err);
+	hash_remove(&conn->he);
 }
 
 
@@ -203,7 +203,6 @@ static void conn_tmr_handler(void *arg)
 	struct sip_conn *conn = arg;
 
 	conn_close(conn, ETIMEDOUT);
-	mem_deref(conn);
 }
 
 
@@ -221,7 +220,6 @@ static void conn_keepalive_handler(void *arg)
 	err = tcp_send(conn->tc, &mb);
 	if (err) {
 		conn_close(conn, err);
-		mem_deref(conn);
 		return;
 	}
 
@@ -448,7 +446,6 @@ static void tcp_recv_handler(struct mbuf *mb, void *arg)
  out:
 	if (err) {
 		conn_close(conn, err);
-		mem_deref(conn);
 	}
 }
 
@@ -492,7 +489,6 @@ static void tcp_close_handler(int err, void *arg)
 	struct sip_conn *conn = arg;
 
 	conn_close(conn, err ? err : ECONNRESET);
-	mem_deref(conn);
 }
 
 


### PR DESCRIPTION
Fix for https://github.com/creytiv/re/issues/261

- Add a new `hash_remove` function which works like `hash_flush` but for a single hashtable entry.
- Remove `mem_deref` calls from `transp.c` and use `hash_remove` in `close_conn` instead.
  - This ensures that when the `conn` has already been removed from the hashtable, e.g. by `hash_flush(sip->ht_conn)`,
    there is no extra `mem_deref` in `transp.c`.

# Testing done
- Compiles fine
- `retest -r` passes
- Tested within two proprietary, internal test suites written in Python
- I have not reproduced this issue in pure C code due to the lack of `request` tests in `retest`.